### PR TITLE
[quad_gantry_level] typos in 300 & 350 configs

### DIFF
--- a/firmware/klipper/configurations/VORON2_stock_300_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_300_printer.cfg
@@ -479,7 +479,7 @@ gcode:
 gantry_corners:
    -60,-10
    360,310
-#   Min & Max gantry corners - measure from nozzle at MIN (0,0) and MAX (250,250) to respective belt positions
+#   Min & Max gantry corners - measure from nozzle at MIN (0,0) and MAX (300,300) to respective belt positions
 points:
    60,60
    60,240

--- a/firmware/klipper/configurations/VORON2_stock_350_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_350_printer.cfg
@@ -478,7 +478,7 @@ gcode:
 gantry_corners:
    -60,-10
    410,360
-#   Min & Max gantry corners - measure from nozzle at MIN (0,0) and MAX (250,250) to respective belt positions
+#   Min & Max gantry corners - measure from nozzle at MIN (0,0) and MAX (350,350) to respective belt positions
 points:
    60,60
    60,290


### PR DESCRIPTION
Changed MAX(250,250) on lines 481 & 482 to reflect printer size.