### PR TITLE
Klipper config - lower max_z_accel, default square_corner_velocity

### DIFF
--- a/firmware/klipper/configurations/VORON2_stock_250_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_250_printer.cfg
@@ -86,8 +86,8 @@ kinematics: corexy
 max_velocity: 250
 max_accel: 2500
 max_z_velocity: 35
-max_z_accel: 800
-square_corner_velocity: 8.0
+max_z_accel: 350
+square_corner_velocity: 5.0
 #   The maximum velocity (in mm/s) that the toolhead may travel a 90
 #   degree corner at. The default is 5mm/s.
 #   For more information, refer to Klipper docs.

--- a/firmware/klipper/configurations/VORON2_stock_250_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_250_printer.cfg
@@ -468,7 +468,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    G0 X179 Y250 F3600
-#   XY Location of the FSR Switch
+#   XY Location of the Z Min Switch. Update to your machines XY location.
    G28 Z
    G0 Z10 F1800
    G0 X125 Y125 Z20 F3600

--- a/firmware/klipper/configurations/VORON2_stock_300_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_300_printer.cfg
@@ -86,8 +86,8 @@ kinematics: corexy
 max_velocity: 250
 max_accel: 2500
 max_z_velocity: 35
-max_z_accel: 800
-square_corner_velocity: 8.0
+max_z_accel: 350
+square_corner_velocity: 5.0
 #   The maximum velocity (in mm/s) that the toolhead may travel a 90
 #   degree corner at. The default is 5mm/s.
 #   For more information, refer to Klipper docs.

--- a/firmware/klipper/configurations/VORON2_stock_300_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_300_printer.cfg
@@ -214,7 +214,6 @@ max_extrude_only_distance: 780
 heater_pin: ar10
 #   D10 on mcu_xye
 max_power: 1.0
-# use "ATC Semitec 104GT-2" for Trianglelab 104GT-2 and 104NT-4-R025H42G sensors
 sensor_type: ATC Semitec 104GT-2
 # use "ATC Semitec 104GT-2" for Trianglelab 104GT-2 and 104NT-4-R025H42G sensors
 # Other sensor types
@@ -469,7 +468,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    G0 X222 Y300 F3600
-#  XY Location of the FSR Switch.  Update to your machines XY location.
+#   XY Location of the Z Min Switch. Update to your machines XY location.
    G28 Z
    G0 Z10 F1800
    G0 X150 Y150 Z10 F3600

--- a/firmware/klipper/configurations/VORON2_stock_350_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_350_printer.cfg
@@ -468,7 +468,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    G0 X272 Y350 F3600
-#   XY Location of the FSR Switch
+#   XY Location of the Z Min Switch. Update to your machines XY location.
    G28 Z
    G0 Z10 F1800
    G0 X175 Y175 Z10 F3600

--- a/firmware/klipper/configurations/VORON2_stock_350_printer.cfg
+++ b/firmware/klipper/configurations/VORON2_stock_350_printer.cfg
@@ -87,7 +87,7 @@ max_velocity: 250
 max_accel: 2500
 max_z_velocity: 25
 max_z_accel: 300
-square_corner_velocity: 8.0
+square_corner_velocity: 5.0
 #   The maximum velocity (in mm/s) that the toolhead may travel a 90
 #   degree corner at. The default is 5mm/s.
 #   For more information, refer to Klipper docs.


### PR DESCRIPTION
- lowered z_accels for 250 & 300mm versions
- changed square_corner_velocity to default value
- updated comments referencing the FSR