### PR TITLE
Introduce travis-ci test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+# This is a travis-ci.org continuous integration configuration file.
+language: node_js
+node_js:
+  - 12
+
+cache:
+  npm: true
+  directories:
+  - travis_cache
+
+before_install:
+  - chmod +x ./travis_scripts/ci-build.sh
+  - npm install remark-cli remark-validate-links
+
+script: ./travis_scripts/ci-build.sh

--- a/Docs/What_the_git.md
+++ b/Docs/What_the_git.md
@@ -17,7 +17,7 @@ latter can be preferred as you will not need a Github account or
 credentials set up. After clicking "Clone or download" make sure you
 see "Clone with HTTPS", and click "Use HTTPS" if you don't.
 
-# Updating a repo (#updating)
+# Updating a repo
 
 To fetch the latest changes, run `git pull origin`. Note that your
 current working directory will need to be inside the repo.
@@ -47,5 +47,5 @@ from different repos overlap. When this occurs git will print an error
 about a conflict, and ask you to fix it.
 
 The most reliable way to fix it is to start fresh, using the command above
-in [Updating a repo](#updating).
+in [Updating a repo](#updating-a-repo).
 

--- a/mods/exquyre/cable_cover/Readme.md
+++ b/mods/exquyre/cable_cover/Readme.md
@@ -3,4 +3,4 @@
 not much to say here, I could fit 3 20AWG wires with thick silicone sleeving in one, but 4 may possibly potentially perhaps fit maybe.
 don't squish the first layer. If it takes more than an index-finger's worth of force you should call an adult.
 
-![F360](cable_cover_F360_screenshot.jpg)
+![F360](cable_cover_F360_screenshot.png)

--- a/travis_scripts/ci-build.sh
+++ b/travis_scripts/ci-build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+BASE_DIR=${PWD}
+CACHE_DIR=${PWD}/travis_cache
+
+chmod +x ${BASE_DIR}/travis_scripts/*.py
+
+ADMESH_DIR=${CACHE_DIR}/admesh-0.98.4
+mkdir -p ${CACHE_DIR}
+cd ${CACHE_DIR}
+if [ ! -d ${ADMESH_DIR} ]; then
+  echo "Admesh cache miss; fetching and building ..."
+  wget https://github.com/admesh/admesh/releases/download/v0.98.4/admesh-0.98.4.tar.gz
+  tar -zxf admesh-0.98.4.tar.gz
+  cd ${ADMESH_DIR}
+  ./configure
+  make
+  chmod +x admesh
+fi
+cd ${BASE_DIR}
+sudo ln -s ${ADMESH_DIR}/admesh /usr/bin/admesh
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  # Compare branch against master
+  git remote set-branches --add origin master
+  git fetch
+  git diff --name-only --diff-filter=AMR origin/master | xargs -n 1 -I {} ${BASE_DIR}/travis_scripts/validate-file.py ${BASE_DIR}/{}
+else
+  # Compare head against the branch to merge into (PR)
+  git diff --name-only --diff-filter=AMR -R HEAD origin/${TRAVIS_BRANCH} | xargs -n 1 -I {} ${BASE_DIR}/travis_scripts/validate-file.py ${BASE_DIR}/{}
+fi
+
+cd ${BASE_DIR}
+
+# Validate all markdown files (eg, README.md).
+remark -u validate-links --no-stdout --frail .
+
+

--- a/travis_scripts/validate-file.py
+++ b/travis_scripts/validate-file.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+import subprocess, re, os, sys, getopt
+
+def read_param(text, parameter):
+    matches = re.search("(" + parameter + ")\s+\:\s+(\d+)", text)
+    #print(matches)
+    if matches:
+        # The decimal group
+        return int(matches.group(2))
+    else:
+        # Uh oh, no match
+        print ("Could not find {0}".format(parameter))
+        exit(1)
+
+def assert_param_threshold(result, parameter, threshold):
+    param_val = read_param(result, parameter)
+    if param_val > threshold:
+        print ("!! Detected \"{0}\" value of {1}".format(parameter, param_val))
+        exit(1)
+    #else:
+        #print ("{0} value OK".format(parameter))
+
+def process_stl(filename):
+    cmd = "admesh \"{0}\"".format(filename)
+    print ("Validating STL {0}".format(filename))
+    result = subprocess.run(cmd, shell=True, check=True, stdout=subprocess.PIPE)
+    output = str(result.stdout)
+
+    assert_param_threshold(output, "Edges fixed", 0)
+    assert_param_threshold(output, "Backwards edges", 0)
+    assert_param_threshold(output, "Degenerate facets", 0)
+    assert_param_threshold(output, "Facets removed", 0)
+    assert_param_threshold(output, "Facets added", 0)
+    assert_param_threshold(output, "Facets reversed", 0)
+    
+def process_markdown(filename):    
+    cmd = "remark -u validate-links --no-stdout --frail \"{0}\"".format(filename)
+    print ("Validating Markdown {0}".format(filename))
+    subprocess.run(cmd, shell=True, check=True)  
+    
+def main(argv):
+    argument = " ".join(sys.argv[1:])
+
+    if argument.lower().endswith(".stl"):
+      process_stl(argument)
+
+if __name__ == "__main__":
+   main(sys.argv[1:])


### PR DESCRIPTION
The aim of this is to introduce some travis-ci tests to the repo.

This will:
### Validate STLs

Any touched (added, modified or moved) STL file is validated through admesh.

The follow properties cannot be greater than zero:
"Edges fixed"
"Backwards edges"
"Degenerate facets"
"Facets removed"
"Facets added"
"Facets reversed"

### Validate all markdown files
- At first I was only going to validate ones that had been touched, but existing markdown files (eg, READMEs) can break by other files being moved or renamed, so this wouldn't necessarily catch all potential problems. Every markdown can be validated in under a second, so it doesn't really add time to the build either.

There were two existing MD files that failed validation. They've been fixed as part of this PR.

### Caching
The "travis_cache" folder and npm are set as cached. So the "remark" npm module and the "admesh" binary will only have to be installed the first time the script runs. 

There are more things on our wish list, but this, at least, is a start.