### PR TITLE
Replace pressure_advance_lookahead_time with pressure_advance_smooth_…

### DIFF
--- a/firmware/klipper_configurations/VORON2_stock_250_printer.cfg
+++ b/firmware/klipper_configurations/VORON2_stock_250_printer.cfg
@@ -242,13 +242,12 @@ max_temp: 270
 #   during deceleration. It is measured in millimeters per
 #   millimeter/second. The default is 0, which disables pressure
 #   advance.
-# pressure_advance_lookahead_time: 0.010
-#   A time (in seconds) to "look ahead" at future extrusion moves when
-#   calculating pressure advance. This is used to reduce the
-#   application of pressure advance during cornering moves that would
-#   otherwise cause retraction followed immediately by pressure
-#   buildup. This setting only applies if pressure_advance is
-#   non-zero. The default is 0.010 (10 milliseconds).
+# pressure_advance_smooth_time: 0.040
+#   A time range (in seconds) to use when calculating the average
+#   extruder velocity for pressure advance. A larger value results in
+#   smoother extruder movements. This parameter may not exceed 200ms.
+#   This setting only applies if pressure_advance is non-zero. The
+#   default is 0.040 (40 milliseconds).
 
 [probe]
 # Inductive Probe

--- a/firmware/klipper_configurations/VORON2_stock_300_printer.cfg
+++ b/firmware/klipper_configurations/VORON2_stock_300_printer.cfg
@@ -242,13 +242,12 @@ max_temp: 270
 #   during deceleration. It is measured in millimeters per
 #   millimeter/second. The default is 0, which disables pressure
 #   advance.
-# pressure_advance_lookahead_time: 0.010
-#   A time (in seconds) to "look ahead" at future extrusion moves when
-#   calculating pressure advance. This is used to reduce the
-#   application of pressure advance during cornering moves that would
-#   otherwise cause retraction followed immediately by pressure
-#   buildup. This setting only applies if pressure_advance is
-#   non-zero. The default is 0.010 (10 milliseconds).
+# pressure_advance_smooth_time: 0.040
+#   A time range (in seconds) to use when calculating the average
+#   extruder velocity for pressure advance. A larger value results in
+#   smoother extruder movements. This parameter may not exceed 200ms.
+#   This setting only applies if pressure_advance is non-zero. The
+#   default is 0.040 (40 milliseconds).
 
 [probe]
 # Inductive Probe

--- a/firmware/klipper_configurations/VORON2_stock_350_printer.cfg
+++ b/firmware/klipper_configurations/VORON2_stock_350_printer.cfg
@@ -242,13 +242,12 @@ max_temp: 270
 #   during deceleration. It is measured in millimeters per
 #   millimeter/second. The default is 0, which disables pressure
 #   advance.
-# pressure_advance_lookahead_time: 0.010
-#   A time (in seconds) to "look ahead" at future extrusion moves when
-#   calculating pressure advance. This is used to reduce the
-#   application of pressure advance during cornering moves that would
-#   otherwise cause retraction followed immediately by pressure
-#   buildup. This setting only applies if pressure_advance is
-#   non-zero. The default is 0.010 (10 milliseconds).
+# pressure_advance_smooth_time: 0.040
+#   A time range (in seconds) to use when calculating the average
+#   extruder velocity for pressure advance. A larger value results in
+#   smoother extruder movements. This parameter may not exceed 200ms.
+#   This setting only applies if pressure_advance is non-zero. The
+#   default is 0.040 (40 milliseconds).
 
 [probe]
 # Inductive Probe


### PR DESCRIPTION
…time in klipper configs
Same as #89 but for the Voron2.1 branch