### PR TITLE
Fix setdisplayneopixel macros on SKR1.3 and 1.4 configs.

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -529,9 +529,9 @@ max_adjust: 10
 #[delayed_gcode setdisplayneopixel]
 #initial_duration: 1
 #gcode:
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3 TRANSMIT=0
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3
 
 #--------------------------------------------------------------------
 

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -529,9 +529,9 @@ max_adjust: 10
 #[delayed_gcode setdisplayneopixel]
 #initial_duration: 1
 #gcode:
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2
-#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3 TRANSMIT=0
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=1 BLUE=1 INDEX=1 TRANSMIT=0
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=2 TRANSMIT=0
+#        SET_LED LED=fysetc_mini12864 RED=1 GREEN=0 BLUE=0 INDEX=3 
 
 #--------------------------------------------------------------------
 


### PR DESCRIPTION
`TRANSMIT=0` has to be applied to all SET_LED calls **but** the last one, instead of the other way around.