### PR TITLE
color_order_GRB is no longer a supported option

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -521,7 +521,6 @@ max_adjust: 10
 #initial_RED: 0.1
 #initial_GREEN: 0.5
 #initial_BLUE: 0.0
-#color_order_GRB: False
 
 ##	Set RGB values on boot up for each Neopixel. 
 ##	Index 1 = display, Index 2 and 3 = Knob

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -522,7 +522,6 @@ max_adjust: 10
 #initial_RED: 0.1
 #initial_GREEN: 0.5
 #initial_BLUE: 0.0
-#color_order_GRB: False
 
 ##	Set RGB values on boot up for each Neopixel. 
 ##	Index 1 = display, Index 2 and 3 = Knob


### PR DESCRIPTION
As of 29 October, 2020 Klipper no longer supports color_order_GRB as a parameter - per this document: https://github.com/KevinOConnor/klipper/blob/master/docs/Config_Changes.md