### PR TITLE
klipper config: update neopixel color_order option

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -521,7 +521,7 @@ max_adjust: 10
 #initial_RED: 0.1
 #initial_GREEN: 0.5
 #initial_BLUE: 0.0
-#color_order_GRB: False
+#color_order: RGB
 
 ##	Set RGB values on boot up for each Neopixel. 
 ##	Index 1 = display, Index 2 and 3 = Knob

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -522,7 +522,7 @@ max_adjust: 10
 #initial_RED: 0.1
 #initial_GREEN: 0.5
 #initial_BLUE: 0.0
-#color_order_GRB: False
+#color_order: RGB
 
 ##	Set RGB values on boot up for each Neopixel. 
 ##	Index 1 = display, Index 2 and 3 = Knob


### PR DESCRIPTION
Per [klipper docs](https://github.com/KevinOConnor/klipper/blob/master/docs/Config_Changes.md):

> 20201029: The neopixel color_order_GRB config option has been removed. If necessary, update the config to set the new color_order option to RGB, GRB, RGBW, or GRBW.