### PR TITLE
Configuration Update

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -84,8 +84,8 @@ kinematics: corexy
 max_velocity: 300  
 max_accel: 3000    			#Max 4000
 max_z_velocity: 15 			#Max 15 for 12V TMC Drivers, can increase for 24V
-max_z_accel: 350   			#Max ?
-square_corner_velocity: 5.0  #Can experiment with 8.0, default 5.0
+max_z_accel: 350
+square_corner_velocity: 5.0
 
 #####################################################################
 # 	X/Y Stepper Settings
@@ -98,7 +98,7 @@ dir_pin: !P2.6
 enable_pin: !P2.1
 rotation_distance: 40
 microsteps: 16
-# full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.28
 position_min: 0
 ##--------------------------------------------------------------------
@@ -121,7 +121,7 @@ homing_retract_dist: 5
 homing_positive_dir: true
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_x]
+[tmc2209 stepper_x]
 uart_pin: P1.17
 interpolate: True
 run_current: 0.8
@@ -136,7 +136,7 @@ dir_pin: !P0.20
 enable_pin: !P2.8
 rotation_distance: 40
 microsteps: 16
-# full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.26
 position_min: 0
 ##--------------------------------------------------------------------
@@ -159,7 +159,7 @@ homing_retract_dist: 5
 homing_positive_dir: true
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_y]
+[tmc2209 stepper_y]
 uart_pin: P1.15
 interpolate: True
 run_current: 0.8
@@ -199,12 +199,12 @@ position_endstop: -0.5
 
 ##--------------------------------------------------------------------
 position_min: -5
-homing_speed: 15.0
-second_homing_speed: 3.0
-homing_retract_dist: 3.0
+homing_speed: 8
+second_homing_speed: 3
+homing_retract_dist: 3
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z]
+[tmc2209 stepper_z]
 uart_pin: z:P1.17
 interpolate: true
 run_current: 0.8
@@ -223,7 +223,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z1]
+[tmc2209 stepper_z1]
 uart_pin: z:P1.15
 interpolate: true
 run_current: 0.8
@@ -242,7 +242,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z2]
+[tmc2209 stepper_z2]
 uart_pin: z:P1.10
 interpolate: true
 run_current: 0.8
@@ -261,7 +261,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z3]
+[tmc2209 stepper_z3]
 uart_pin: z:P1.8
 interpolate: true
 run_current: 0.8
@@ -279,13 +279,17 @@ stealthchop_threshold: 0
 step_pin: P2.13
 dir_pin: P0.11
 enable_pin: !P2.12
-##	16 microsteps Mobius 3 ~= 0.00180
 ##	Update value below when you perform extruder calibration
 ##	If you ask for 100mm of filament, but in reality it is 98mm:
 ##	rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / 100
-##  7.68 a good starting value for Afterburner, 5.76 for Mobius
-rotation_distance: 7.68
+##  22.6789511 is a good starting point
+rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
+##	Update Gear Ratio depending on your Extruder Type
+##	Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
+##	Use 80:20 for M4, M3.1
+gear_ratio: 50:17
 microsteps: 16
+full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: P2.7
@@ -307,7 +311,7 @@ pressure_advance_smooth_time: 0.040
 
 ##	E0 on MCU X/Y
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX extruder]
+[tmc2209 extruder]
 uart_pin: P1.9
 interpolate: false
 run_current: 0.5
@@ -322,7 +326,7 @@ stealthchop_threshold: 0
 [heater_bed]
 ##	SSR Pin - Z board, Fan Pin
 heater_pin: z:P2.3
-sensor_type: NTC 100K MGB18-104F39050L32
+sensor_type: NTC 100K beta 3950
 sensor_pin: z:P0.23
 ##	Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6
@@ -398,10 +402,13 @@ heater_temp: 45.0
 #####################################################################
 
 #[output_pin caselight ]
+# Chamber Lighting - Bed Connector (Optional)
 #pin: P2.5
-#pwm: true
-#value: 0
-#scale: 10
+#pwm:true
+#shutdown_value: 0
+#value:100
+#cycle_time: 0.01
+#scale: 100
 
 #####################################################################
 # 	Homing and Gantry Adjustment Routines

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -84,8 +84,8 @@ kinematics: corexy
 max_velocity: 300  
 max_accel: 3000    			#Max 4000
 max_z_velocity: 15 			#Max 15 for 12V TMC Drivers, can increase for 24V
-max_z_accel: 350   			#Max ?
-square_corner_velocity: 5.0  #Can experiment with 8.0, default 5.0
+max_z_accel: 350
+square_corner_velocity: 5.0
 
 #####################################################################
 # 	X/Y Stepper Settings
@@ -98,7 +98,7 @@ dir_pin: !P2.6
 enable_pin: !P2.1
 rotation_distance: 40
 microsteps: 16
-# full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.29
 position_min: 0
 ##--------------------------------------------------------------------
@@ -121,7 +121,7 @@ homing_retract_dist: 5
 homing_positive_dir: true
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_x]
+[tmc2209 stepper_x]
 uart_pin: P1.10
 interpolate: True
 run_current: 0.8
@@ -136,7 +136,7 @@ dir_pin: !P0.20
 enable_pin: !P2.8
 rotation_distance: 40
 microsteps: 16
-# full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
+full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.28
 position_min: 0
 ##--------------------------------------------------------------------
@@ -159,7 +159,7 @@ homing_retract_dist: 5
 homing_positive_dir: true
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_y]
+[tmc2209 stepper_y]
 uart_pin: P1.9
 interpolate: True
 run_current: 0.8
@@ -199,12 +199,12 @@ position_endstop: -0.5
 
 ##--------------------------------------------------------------------
 position_min: -5
-homing_speed: 15.0
-second_homing_speed: 3.0
-homing_retract_dist: 3.0
+homing_speed: 8
+second_homing_speed: 3
+homing_retract_dist: 3
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z]
+[tmc2209 stepper_z]
 uart_pin: z:P1.10
 interpolate: true
 run_current: 0.8
@@ -223,7 +223,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z1]
+[tmc2209 stepper_z1]
 uart_pin: z:P1.9
 interpolate: true
 run_current: 0.8
@@ -242,7 +242,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z2]
+[tmc2209 stepper_z2]
 uart_pin: z:P1.8
 interpolate: true
 run_current: 0.8
@@ -261,7 +261,7 @@ gear_ratio: 80:16
 microsteps: 16
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX stepper_z3]
+[tmc2209 stepper_z3]
 uart_pin: z:P1.4
 interpolate: true
 run_current: 0.8
@@ -279,13 +279,17 @@ stealthchop_threshold: 0
 step_pin: P2.13
 dir_pin: P0.11
 enable_pin: !P2.12
-##	16 microsteps Mobius 3 ~= 0.00180
 ##	Update value below when you perform extruder calibration
 ##	If you ask for 100mm of filament, but in reality it is 98mm:
 ##	rotation_distance = <previous_rotation_distance> * <actual_extrude_distance> / 100
-##  7.68 a good starting value for Afterburner, 5.76 for Mobius
-rotation_distance: 7.68
+##  22.6789511 is a good starting point
+rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
+##	Update Gear Ratio depending on your Extruder Type
+##	Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
+##	Use 80:20 for M4, M3.1
+gear_ratio: 50:17				#BMG Gear Ratio
 microsteps: 16
+full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: P2.7
@@ -307,7 +311,7 @@ pressure_advance_smooth_time: 0.040
 
 ##	E0 on MCU X/Y
 ##	Make sure to update below for your relevant driver (2208 or 2209)
-[tmcXXXX extruder]
+[tmc2209 extruder]
 uart_pin: P1.4
 interpolate: false
 run_current: 0.5
@@ -322,7 +326,7 @@ stealthchop_threshold: 0
 [heater_bed]
 ##	SSR Pin - Z board, Fan Pin
 heater_pin: z:P2.3
-sensor_type: NTC 100K MGB18-104F39050L32
+sensor_type: NTC 100K beta 3950
 sensor_pin: z:P0.25
 ##	Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6
@@ -352,7 +356,6 @@ samples_result: median
 sample_retract_dist: 3.0
 samples_tolerance: 0.006
 samples_tolerance_retries: 3
-
 
 #####################################################################
 # 	Fan Control
@@ -399,10 +402,13 @@ heater_temp: 45.0
 #####################################################################
 
 #[output_pin caselight ]
+# Chamber Lighting - Bed Connector (Optional)
 #pin: P2.5
-#pwm: true
-#value: 0
-#scale: 10
+#pwm:true
+#shutdown_value: 0
+#value:100
+#cycle_time: 0.01
+#scale: 100
 
 #####################################################################
 # 	Homing and Gantry Adjustment Routines


### PR DESCRIPTION
-Fix incorrect bed thermistor
-Update extruder to use gear_ratio
-Set 2209 as default for all stepper motors
-Lower default Z home speed (previous value was too fast--crash nozzle before able to react)
-Update Caselight configuration