### PR TITLE
Caselight tweaks

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -401,14 +401,13 @@ heater_temp: 45.0
 # 	LED Control
 #####################################################################
 
-#[output_pin caselight ]
+#[output_pin caselight]
 # Chamber Lighting - Bed Connector (Optional)
 #pin: P2.5
 #pwm:true
 #shutdown_value: 0
 #value:100
 #cycle_time: 0.01
-#scale: 100
 
 #####################################################################
 # 	Homing and Gantry Adjustment Routines

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -401,14 +401,13 @@ heater_temp: 45.0
 # 	LED Control
 #####################################################################
 
-#[output_pin caselight ]
+#[output_pin caselight]
 # Chamber Lighting - Bed Connector (Optional)
 #pin: P2.5
 #pwm:true
 #shutdown_value: 0
 #value:100
 #cycle_time: 0.01
-#scale: 100
 
 #####################################################################
 # 	Homing and Gantry Adjustment Routines


### PR DESCRIPTION
The stock printer.cfg's caselight entry doesn't quite play nice with klipper's display module.  These two small tweaks resolve that.