### PR TITLE
Stock config safety tweak

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -426,7 +426,7 @@ gcode:
    ##	XY Location of the Z Endstop Switch
    ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
-   G0 X0 Y0 F3600 
+   G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -424,7 +424,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    ##	XY Location of the Z Endstop Switch
-   ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
+   ##	Update X-10 and Y-10 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -3,7 +3,8 @@
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths							[mcu] section
 ## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
-## Z Endstop Switch location       		[homing_override] section
+## Z Endstop Switch location			[safe_z_home] section
+## Homing end position				[gcode_macro G32] section
 ## Z Endstop Switch  offset for Z0		[stepper_z] section
 ## Probe points							[quad_gantry_level] section
 ## Min & Max gantry corner postions		[quad_gantry_level] section
@@ -416,33 +417,14 @@ heater_temp: 45.0
 [idle_timeout]
 timeout: 1800
 
-[homing_override]
-axes: z
-set_position_z: 0
-gcode:
-   G90
-   G0 Z5 F600
-   G28 X Y
-   ##	XY Location of the Z Endstop Switch
-   ##	Update X-10 and Y-10 to your values (such as X157, Y305) after going through
-   ##	Z Endstop Pin Location Definition step.
-   G0 X-10 Y-10 F3600 
-   
-   G28 Z
-   G0 Z10 F1800
-   
-   	##	Uncomment for for your size printer:
-#--------------------------------------------------------------------
-   	##	Uncomment for 250mm build
-   	#G0 X125 Y125 Z30 F3600
-   
-	##	Uncomment for 300 build
-   	#G0 X150 Y150 Z30 F3600
-   
-	##	Uncomment for 350mm build
-   	#G0 X175 Y175 Z30 F3600
-#--------------------------------------------------------------------
-
+[safe_z_home]
+##	XY Location of the Z Endstop Switch
+##	Update -10,-10 to the XY coordinates of your endstop pin 
+##	(such as 157,305) after going through Z Endstop Pin
+##	Location Definition step.
+home_xy_position:-10,-10
+speed:100
+z_hop:10
    
 [quad_gantry_level]
 ##	Use QUAD_GANTRY_LEVEL to level a gantry.
@@ -557,12 +539,22 @@ gcode:
     G28
     QUAD_GANTRY_LEVEL
     G28
-    G0 X150 Y150 Z20 F6000
+    ##	Uncomment for for your size printer:
+    #--------------------------------------------------------------------
+    ##	Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
+    
+    ##	Uncomment for 300 build
+    #G0 X150 Y150 Z30 F3600
+    
+    ##	Uncomment for 350mm build
+    #G0 X175 Y175 Z30 F3600
+    #--------------------------------------------------------------------
    
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
-    G28                            ; home all axes
+    G32                            ; home all axes
     G1 Z20 F3000                   ; move nozzle away from bed
    
 

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -3,7 +3,8 @@
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths							[mcu] section
 ## Thermistor types						[extruder] and [heater_bed] sections - See 'sensor types' list at end of file
-## Z Endstop Switch location			[homing_override] section
+## Z Endstop Switch location			[safe_z_home] section
+## Homing end position				[gcode_macro G32] section
 ## Z Endstop Switch  offset for Z0		[stepper_z] section
 ## Probe points							[quad_gantry_level] section
 ## Min & Max gantry corner postions		[quad_gantry_level] section
@@ -416,32 +417,16 @@ heater_temp: 45.0
 [idle_timeout]
 timeout: 1800
 
-[homing_override]
-axes: z
-set_position_z: 0
-gcode:
-   G90
-   G0 Z5 F600
-   G28 X Y
-   ##	XY Location of the Z Endstop Switch
-   ##	Update X-10 and Y-10 to your values (such as X157, Y305) after going through
-   ##	Z Endstop Pin Location Definition step.
-   G0 X-10 Y-10 F3600 
+[safe_z_home]
+##	XY Location of the Z Endstop Switch
+##	Update -10,-10 to the XY coordinates of your endstop pin 
+##	(such as 157,305) after going through Z Endstop Pin
+##	Location Definition step.
+home_xy_position:-10,-10
+speed:100
+z_hop:10
    
-   G28 Z
-   G0 Z10 F1800
-   
-   	##	Uncomment for for your size printer:
-#--------------------------------------------------------------------
-   	##	Uncomment for 250mm build
-   	#G0 X125 Y125 Z30 F3600
-   
-	##	Uncomment for 300 build
-   	#G0 X150 Y150 Z30 F3600
-   
-	##	Uncomment for 350mm build
-   	#G0 X175 Y175 Z30 F3600
-#--------------------------------------------------------------------
+
 
    
 [quad_gantry_level]
@@ -556,12 +541,22 @@ gcode:
     G28
     QUAD_GANTRY_LEVEL
     G28
-    G0 X150 Y150 Z20 F6000
+    ##	Uncomment for for your size printer:
+    #--------------------------------------------------------------------
+    ##	Uncomment for 250mm build
+    #G0 X125 Y125 Z30 F3600
+    
+    ##	Uncomment for 300 build
+    #G0 X150 Y150 Z30 F3600
+    
+    ##	Uncomment for 350mm build
+    #G0 X175 Y175 Z30 F3600
+    #--------------------------------------------------------------------
    
 [gcode_macro PRINT_START]
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
-    G28                            ; home all axes
+    G32                            ; home all axes
     G1 Z20 F3000                   ; move nozzle away from bed
    
 

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -426,7 +426,7 @@ gcode:
    ##	XY Location of the Z Endstop Switch
    ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
-   G0 X0 Y0 F3600 
+   G0 X-10 Y-10 F3600 
    
    G28 Z
    G0 Z10 F1800

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -424,7 +424,7 @@ gcode:
    G0 Z5 F600
    G28 X Y
    ##	XY Location of the Z Endstop Switch
-   ##	Update X0 and Y0 to your values (such as X157, Y305) after going through
+   ##	Update X-10 and Y-10 to your values (such as X157, Y305) after going through
    ##	Z Endstop Pin Location Definition step.
    G0 X-10 Y-10 F3600 
    

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -425,10 +425,7 @@ timeout: 1800
 home_xy_position:-10,-10
 speed:100
 z_hop:10
-   
 
-
-   
 [quad_gantry_level]
 ##	Use QUAD_GANTRY_LEVEL to level a gantry.
 ##	Min & Max gantry corners - measure from nozzle at MIN (0,0) and 


### PR DESCRIPTION
By setting the user updated pin position to (-10,-10) in the stock config, we cause people who haven't read the instructions and updated the position to end up with an move-out-of-range error, instead of a potential head crash.