### PR TITLE
Adds a check for printer boundaries in PRINT_END macro

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -561,11 +561,41 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    #   Get boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+
+    #   Set end move values
+    {% set move_x = 20.0 %}
+    {% set move_y = 20.0 %}
+    {% set move_z = 2.0 %}
+
+    #   Check end position to determine safe directions to move
+    {% if printer.toolhead.position.x < (max_x - move_x) %}
+        {% set x_safe = move_x %}
+    {% else %}
+        {% set x_safe = -move_x %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < (max_y - move_y) %}
+        {% set y_safe = move_y %}
+    {% else %}
+        {% set y_safe = -move_y %}
+    {% endif %}
+
+    {% if printer.toolhead.position.z < (max_z - move_z) %}
+        {% set z_safe = move_z %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+    
+   #	Commence Print End
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
     G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G1 Z2 F3000                    ; move nozzle up 2mm

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -595,7 +595,7 @@ gcode:
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
     G91                            ; relative positioning
-    G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
+    G0 Z{z_safe} X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G90                            ; absolute positioning

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -598,9 +598,8 @@ gcode:
     G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
     G90                            ; absolute positioning
-    G0  X125 Y250 F3600            ; park nozzle at rear
+    G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
     BED_MESH_CLEAR
     
 ## 	Thermistor Types

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -560,11 +560,41 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    #   Get boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+
+    #   Set end move values
+    {% set move_x = 20.0 %}
+    {% set move_y = 20.0 %}
+    {% set move_z = 2.0 %}
+
+    #   Check end position to determine safe directions to move
+    {% if printer.toolhead.position.x < (max_x - move_x) %}
+        {% set x_safe = move_x %}
+    {% else %}
+        {% set x_safe = -move_x %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < (max_y - move_y) %}
+        {% set y_safe = move_y %}
+    {% else %}
+        {% set y_safe = -move_y %}
+    {% endif %}
+
+    {% if printer.toolhead.position.z < (max_z - move_z) %}
+        {% set z_safe = move_z %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+    
+   #	Commence Print End
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
     G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G1 Z2 F3000                    ; move nozzle up 2mm

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -597,9 +597,8 @@ gcode:
     G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
     G90                            ; absolute positioning
-    G0  X125 Y250 F3600            ; park nozzle at rear
+    G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
     BED_MESH_CLEAR
     
 ## 	Thermistor Types

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -594,7 +594,7 @@ gcode:
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
     G91                            ; relative positioning
-    G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
+    G0 Z{z_safe} X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G90                            ; absolute positioning

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -526,9 +526,8 @@ gcode:
     G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
     G90                            ; absolute positioning
-    G0  X125 Y250 F3600            ; park nozzle at rear
+    G0 X{max_x / 2} Y{max_y} F3600   ; park nozzle at rear
     BED_MESH_CLEAR
     
 ## 	Common Temperature Sensors

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -489,11 +489,41 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    #   Get boundaries
+    {% set max_x = printer.configfile.config["stepper_x"]["position_max"]|float %}
+    {% set max_y = printer.configfile.config["stepper_y"]["position_max"]|float %}
+    {% set max_z = printer.configfile.config["stepper_z"]["position_max"]|float %}
+
+    #   Set end move values
+    {% set move_x = 20.0 %}
+    {% set move_y = 20.0 %}
+    {% set move_z = 2.0 %}
+
+    #   Check end position to determine safe directions to move
+    {% if printer.toolhead.position.x < (max_x - move_x) %}
+        {% set x_safe = move_x %}
+    {% else %}
+        {% set x_safe = -move_x %}
+    {% endif %}
+
+    {% if printer.toolhead.position.y < (max_y - move_y) %}
+        {% set y_safe = move_y %}
+    {% else %}
+        {% set y_safe = -move_y %}
+    {% endif %}
+
+    {% if printer.toolhead.position.z < (max_z - move_z) %}
+        {% set z_safe = move_z %}
+    {% else %}
+        {% set z_safe = max_z - printer.toolhead.position.z %}
+    {% endif %}
+    
+   #	Commence Print End
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
     G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G1 Z2 F3000                    ; move nozzle up 2mm

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -523,7 +523,7 @@ gcode:
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
     G91                            ; relative positioning
-    G0 Z{safe_z} X{safe_x} Y{safe_Y} F20000    ; move nozzle to remove stringing
+    G0 Z{z_safe} X{x_safe} Y{y_safe} F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
     M107                           ; turn off fan
     G90                            ; absolute positioning


### PR DESCRIPTION
Checks the current printhead position against printer boundaries to determine safe direction and distance to move the printhead when the print is finished.  This fixes the `Move out of range` Klipper error some users may be experiencing with larger prints are finished.