### PR TITLE
Update SKR klipper configs to match newest Klipper recommendations.

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -98,7 +98,7 @@ step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
 rotation_distance: 40
-microsteps: 16
+microsteps: 32
 full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.28
 position_min: 0
@@ -124,9 +124,9 @@ homing_positive_dir: true
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_x]
 uart_pin: P1.17
-interpolate: True
+interpolate: false
 run_current: 0.8
-hold_current: 0.7
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -136,7 +136,7 @@ step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
 rotation_distance: 40
-microsteps: 16
+microsteps: 32
 full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.26
 position_min: 0
@@ -162,9 +162,9 @@ homing_positive_dir: true
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_y]
 uart_pin: P1.15
-interpolate: True
+interpolate: false
 run_current: 0.8
-hold_current: 0.7
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
  
@@ -180,7 +180,7 @@ dir_pin: !z:P2.6
 enable_pin: !z:P2.1
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 endstop_pin: z:P1.25
 ##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
 ##  (+) value = endstop above Z0, (-) value = endstop below
@@ -190,13 +190,13 @@ position_endstop: -0.5
 ##--------------------------------------------------------------------
 
 ##	Uncomment below for 250mm build
-#position_max: 240
+#position_max: 230
 
 ##	Uncomment below for 300mm build
-#position_max: 290
+#position_max: 280
 
 ##	Uncomment below for 350mm build
-#position_max: 340
+#position_max: 330
 
 ##--------------------------------------------------------------------
 position_min: -5
@@ -207,7 +207,7 @@ homing_retract_dist: 3
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z]
 uart_pin: z:P1.17
-interpolate: true
+interpolate: false
 run_current: 0.8
 hold_current: 0.8
 sense_resistor: 0.110
@@ -221,14 +221,14 @@ dir_pin: z:P0.20
 enable_pin: !z:P2.8
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z1]
 uart_pin: z:P1.15
-interpolate: true
+interpolate: false
 run_current: 0.8
-hold_current: 0.80
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -240,14 +240,14 @@ dir_pin: !z:P2.11
 enable_pin: !z:P0.21
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z2]
 uart_pin: z:P1.10
-interpolate: true
+interpolate: false
 run_current: 0.8
-hold_current: 0.80
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -259,14 +259,14 @@ dir_pin: z:P0.11
 enable_pin: !z:P2.12
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z3]
 uart_pin: z:P1.8
-interpolate: true
+interpolate: false
 run_current: 0.8
-hold_current: 0.80
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -289,13 +289,14 @@ rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
 ##	Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
 ##	Use 80:20 for M4, M3.1
 gear_ratio: 50:17
-microsteps: 16
+microsteps: 32
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: P2.7
-##	Validate the following thermistor type to make sure it is correct
-sensor_type: ATC Semitec 104GT-2
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+# sensor_type: ATC Semitec 104GT-2
 sensor_pin: P0.24
 min_temp: 10
 max_temp: 270
@@ -316,7 +317,7 @@ pid_kd = 131.721
 uart_pin: P1.9
 interpolate: false
 run_current: 0.5
-hold_current: 0.4
+hold_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -327,7 +328,9 @@ stealthchop_threshold: 0
 [heater_bed]
 ##	SSR Pin - Z board, Fan Pin
 heater_pin: z:P2.3
-sensor_type: NTC 100K beta 3950
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+# sensor_type: Generic 3950
 sensor_pin: z:P0.23
 ##	Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6
@@ -572,12 +575,3 @@ gcode:
     G90                            ; absolute positioning
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
-    
-## 	Thermistor Types
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "NTC 100K beta 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
-##   "AD595"
-##   "PT100 INA826"

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -126,7 +126,6 @@ homing_positive_dir: true
 uart_pin: P1.10
 interpolate: false
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -164,7 +163,6 @@ homing_positive_dir: true
 uart_pin: P1.9
 interpolate: false
 run_current: 0.8
-hold_current: 0.7
 sense_resistor: 0.110
 stealthchop_threshold: 0
  
@@ -209,7 +207,6 @@ homing_retract_dist: 3
 uart_pin: z:P1.10
 interpolate: false
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -228,7 +225,6 @@ microsteps: 32
 uart_pin: z:P1.9
 interpolate: false
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -247,7 +243,6 @@ microsteps: 32
 uart_pin: z:P1.8
 interpolate: false
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -266,7 +261,6 @@ microsteps: 32
 uart_pin: z:P1.4
 interpolate: false
 run_current: 0.8
-hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -317,7 +311,6 @@ pid_kd = 131.721
 uart_pin: P1.4
 interpolate: false
 run_current: 0.5
-hold_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0
 

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -98,7 +98,7 @@ step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
 rotation_distance: 40
-microsteps: 16
+microsteps: 32
 full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.29
 position_min: 0
@@ -124,9 +124,9 @@ homing_positive_dir: true
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_x]
 uart_pin: P1.10
-interpolate: True
+interpolate: false
 run_current: 0.8
-hold_current: 0.7
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -136,7 +136,7 @@ step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
 rotation_distance: 40
-microsteps: 16
+microsteps: 32
 full_steps_per_rotation:200  #set to 400 for 0.9 degree stepper
 endstop_pin: P1.28
 position_min: 0
@@ -162,7 +162,7 @@ homing_positive_dir: true
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_y]
 uart_pin: P1.9
-interpolate: True
+interpolate: false
 run_current: 0.8
 hold_current: 0.7
 sense_resistor: 0.110
@@ -180,7 +180,7 @@ dir_pin: !z:P2.6
 enable_pin: !z:P2.1
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 endstop_pin: z:P1.27
 ##  Z-position of nozzle (in mm) to z-endstop trigger point relative to print surface (Z0)
 ##  (+) value = endstop above Z0, (-) value = endstop below
@@ -190,13 +190,13 @@ position_endstop: -0.5
 ##--------------------------------------------------------------------
 
 ##	Uncomment below for 250mm build
-#position_max: 240
+#position_max: 230
 
 ##	Uncomment below for 300mm build
-#position_max: 290
+#position_max: 280
 
 ##	Uncomment below for 350mm build
-#position_max: 340
+#position_max: 330
 
 ##--------------------------------------------------------------------
 position_min: -5
@@ -207,7 +207,7 @@ homing_retract_dist: 3
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z]
 uart_pin: z:P1.10
-interpolate: true
+interpolate: false
 run_current: 0.8
 hold_current: 0.8
 sense_resistor: 0.110
@@ -221,12 +221,12 @@ dir_pin: z:P0.20
 enable_pin: !z:P2.8
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z1]
 uart_pin: z:P1.9
-interpolate: true
+interpolate: false
 run_current: 0.8
 hold_current: 0.8
 sense_resistor: 0.110
@@ -240,14 +240,14 @@ dir_pin: !z:P2.11
 enable_pin: !z:P0.21
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z2]
 uart_pin: z:P1.8
-interpolate: true
+interpolate: false
 run_current: 0.8
-hold_current: 0.80
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -259,14 +259,14 @@ dir_pin: z:P0.11
 enable_pin: !z:P2.12
 rotation_distance: 40
 gear_ratio: 80:16
-microsteps: 16
+microsteps: 32
 
 ##	Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z3]
 uart_pin: z:P1.4
-interpolate: true
+interpolate: false
 run_current: 0.8
-hold_current: 0.80
+hold_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -289,13 +289,14 @@ rotation_distance: 22.6789511	#Bondtech 5mm Drive Gears
 ##	Use 50:17 for Afterburner/Clockwork (BMG Gear Ratio)
 ##	Use 80:20 for M4, M3.1
 gear_ratio: 50:17				#BMG Gear Ratio
-microsteps: 16
+microsteps: 32
 full_steps_per_rotation: 200	#200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
 heater_pin: P2.7
-##	Validate the following thermistor type to make sure it is correct
-sensor_type: ATC Semitec 104GT-2
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+# sensor_type: Generic 3950
 sensor_pin: P0.24
 min_temp: 10
 max_temp: 270
@@ -316,7 +317,7 @@ pid_kd = 131.721
 uart_pin: P1.4
 interpolate: false
 run_current: 0.5
-hold_current: 0.4
+hold_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
@@ -327,7 +328,9 @@ stealthchop_threshold: 0
 [heater_bed]
 ##	SSR Pin - Z board, Fan Pin
 heater_pin: z:P2.3
-sensor_type: NTC 100K beta 3950
+##  Validate the following thermistor type to make sure it is correct
+##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
+# sensor_type: Generic 3950
 sensor_pin: z:P0.25
 ##	Adjust Max Power so your heater doesn't warp your bed
 max_power: 0.6
@@ -571,12 +574,3 @@ gcode:
     G90                            ; absolute positioning
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
-    
-## 	Thermistor Types
-##   "EPCOS 100K B57560G104F"
-##   "ATC Semitec 104GT-2"
-##   "NTC 100K beta 3950"
-##   "Honeywell 100K 135-104LAG-J01"
-##   "NTC 100K MGB18-104F39050L32" (Keenovo Heater Pad)
-##   "AD595"
-##   "PT100 INA826"


### PR DESCRIPTION
* Remove Interpolation from all steppers. 
* Increased microsteps to 32. 
* Set run_current = hold_current. 
* Updated link to thermistor types.
* Reduced z height choices to prevent crashes at max z

Relevant Klipper pull request here: https://github.com/Klipper3d/klipper/pull/4977