### PR TITLE
Update retraction speeds and lengths

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -555,7 +555,7 @@ gcode:
     
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-2.0 F3600                 ; retract filament
+    G1 E-2.0 F2400                 ; retract filament
     
     TURN_OFF_HEATERS
     

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -555,7 +555,7 @@ gcode:
     
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-2.0 F2400                 ; retract filament
+    G1 E-5.0 F1800                 ; retract filament
     
     TURN_OFF_HEATERS
     

--- a/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_250_printer.cfg
+++ b/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_250_printer.cfg
@@ -541,7 +541,7 @@ gcode:
 gcode:
    M400                           ; wait for buffer to clear
    G92 E0                         ; zero the extruder
-   G1 E-2 F2400                   ; retract filament
+   G1 E-5 F1800                   ; retract filament
    G91                            ; relative positioning
    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
    TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_250_printer.cfg
+++ b/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_250_printer.cfg
@@ -541,7 +541,7 @@ gcode:
 gcode:
    M400                           ; wait for buffer to clear
    G92 E0                         ; zero the extruder
-   G1 E-4.0 F3600                 ; retract filament
+   G1 E-2 F2400                   ; retract filament
    G91                            ; relative positioning
    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
    TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_300_printer.cfg
+++ b/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_300_printer.cfg
@@ -541,7 +541,7 @@ gcode:
 gcode:
    M400                           ; wait for buffer to clear
    G92 E0                         ; zero the extruder
-   G1 E-2 F2400                   ; retract filament
+   G1 E-5 F1800                   ; retract filament
    G91                            ; relative positioning
    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
    TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_300_printer.cfg
+++ b/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_300_printer.cfg
@@ -541,7 +541,7 @@ gcode:
 gcode:
    M400                           ; wait for buffer to clear
    G92 E0                         ; zero the extruder
-   G1 E-4.0 F3600                 ; retract filament
+   G1 E-2 F2400                   ; retract filament
    G91                            ; relative positioning
    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
    TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_350_printer.cfg
+++ b/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_350_printer.cfg
@@ -542,7 +542,7 @@ gcode:
 gcode:
    M400                           ; wait for buffer to clear
    G92 E0                         ; zero the extruder
-   G1 E-2 F2400                   ; retract filament
+   G1 E-5 F1800                   ; retract filament
    G91                            ; relative positioning
    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
    TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_350_printer.cfg
+++ b/firmware/klipper_configurations/RAMPS (Old)/VORON2_RAMPS_350_printer.cfg
@@ -542,7 +542,7 @@ gcode:
 gcode:
    M400                           ; wait for buffer to clear
    G92 E0                         ; zero the extruder
-   G1 E-4.0 F3600                 ; retract filament
+   G1 E-2 F2400                   ; retract filament
    G91                            ; relative positioning
    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
    TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -563,7 +563,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-10.0 F3600                ; retract filament
+    G1 E-2 F2400                   ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -563,7 +563,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-2 F2400                   ; retract filament
+    G1 E-5 F1800                   ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -562,7 +562,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-10.0 F3600                ; retract filament
+    G1 E-2 F2400                   ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -562,7 +562,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-2 F2400                   ; retract filament
+    G1 E-5 F1800                   ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -491,7 +491,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-10.0 F3600                ; retract filament
+    G1 E-2 F2400                ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -491,7 +491,7 @@ gcode:
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-2 F2400                ; retract filament
+    G1 E-5 F1800                ; retract filament
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS


### PR DESCRIPTION
I changed all default lengths and speeds to both be consistent and have a short default length. Yanking it 10mm back at 60mm/s is just asking for trouble. There's been many clogs because of these defaults. This is a safe startingpoint that might be a little annoying with ooze during next print, but users can tweak this WITHOUT a clogged hotend.