### PR TITLE
fix missing double # on some comments.

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -223,9 +223,9 @@ stealthchop_threshold: 0
 #   Extruder
 #####################################################################
 
-#   Connected to MOTOR_6
-#   Heater - HE0
-#   Thermistor - T0
+##  Connected to MOTOR_6
+##  Heater - HE0
+##  Thermistor - T0
 [extruder]
 step_pin: PE2
 dir_pin: PE3
@@ -363,8 +363,8 @@ heater: heater_bed
 #   LED Control
 #####################################################################
 
+## Chamber Lighting - HE2 Connector (Optional)
 #[output_pin caselight]
-# Chamber Lighting - HE2 Connector (Optional)
 #pin: PB10
 #pwm:true
 #shutdown_value: 0


### PR DESCRIPTION
Single # comments on a couple lines are confusing some users thinking they need to be uncommented.