### PR TITLE
Remove leading spaces from selectable config options 

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -246,7 +246,7 @@ filament_diameter: 1.75
 heater_pin: PA2
 ##  Validate the following thermistor type to make sure it is correct
 ##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
-# sensor_type: ATC Semitec 104GT-2
+#sensor_type: ATC Semitec 104GT-2
 sensor_pin: PF4
 min_temp: 10
 max_temp: 270
@@ -257,9 +257,9 @@ pid_kp = 26.213
 pid_ki = 1.304
 pid_kd = 131.721
 ##  Try to keep pressure_advance below 1.0
-# pressure_advance: 0.05
+#pressure_advance: 0.05
 ##  Default is 0.040, leave stock
-# pressure_advance_smooth_time: 0.040
+#pressure_advance_smooth_time: 0.040
 
 ##  E0 on MOTOR6
 ##  Make sure to update below for your relevant driver (2208 or 2209)
@@ -281,7 +281,7 @@ stealthchop_threshold: 0
 heater_pin: PA3
 ##  Validate the following thermistor type to make sure it is correct
 ##  See https://www.klipper3d.org/Config_Reference.html#common-thermistors for additional options
-# sensor_type: Generic 3950
+#sensor_type: Generic 3950
 sensor_pin: PF3
 ##  Adjust Max Power so your heater doesn't warp your bed. Rule of thumb is 0.4 watts / cm^2 .
 max_power: 0.6
@@ -302,11 +302,11 @@ pid_kd: 363.769
 
 ## Select the probe port by type:
 ## For the PROBE port. Will not work with Diode. May need pull-up resistor from signal to 24V.
-# pin: ~!PB7
+#pin: ~!PB7
 ## For the DIAG_7 port. NEEDS BAT85 DIODE! Change to !PG15 if probe is NO.
-# pin: PG15
+#pin: PG15
 ## For Octopus Pro PROBE port; NPN and PNP proximity switch types can be set by jumper
-# pin: ~!PC5
+#pin: ~!PC5
 
 #--------------------------------------------------------------------
 


### PR DESCRIPTION
The spaces are causing issues for people who are not familiar with klipper's config syntax and think they only need to remove the `#`. No actually code or functionality changes were made.