### PR TITLE
Remove bed_mesh_clear from g32 in v2 configs.

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -519,7 +519,6 @@ aliases:
 
 [gcode_macro G32]
 gcode:
-    BED_MESH_CLEAR
     G28
     QUAD_GANTRY_LEVEL
     G28

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -535,7 +535,6 @@ max_adjust: 10
 
 [gcode_macro G32]
 gcode:
-    BED_MESH_CLEAR
     G28
     QUAD_GANTRY_LEVEL
     G28

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -534,7 +534,6 @@ max_adjust: 10
 
 [gcode_macro G32]
 gcode:
-    BED_MESH_CLEAR
     G28
     QUAD_GANTRY_LEVEL
     G28

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -464,7 +464,6 @@ gcode:
 
 [gcode_macro G32]
 gcode:
-    BED_MESH_CLEAR
     G28
     QUAD_GANTRY_LEVEL
     G28


### PR DESCRIPTION
Kevin says having a bed mesh enabled doesn't impact QGL, so there's no need to include a BED_MESH_CLEAR command in g32.