### PR TITLE
Octopus config: Run hotend fan in case of shutdown

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -343,6 +343,8 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
+##  Heat creep protection: In case of MCU shutdown, keep this fan running
+shutdown_speed: 1	
 ##  If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -362,6 +362,8 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
+##  Heat creep protection: In case of MCU shutdown, keep this fan running
+shutdown_speed: 1	
 ##	If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -362,6 +362,8 @@ max_power: 1.0
 kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
+##  Heat creep protection: In case of MCU shutdown, keep this fan running
+shutdown_speed: 1	
 ##	If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -303,6 +303,8 @@ max_power: 1.0
 #kick_start_time: 0.5
 heater: extruder
 heater_temp: 50.0
+##  Heat creep protection: In case of MCU shutdown, keep this fan running
+shutdown_speed: 1	
 ##	If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 


### PR DESCRIPTION
In case the MCU is shutdown from any kind of failure, it is good practice to have the hotend fan running to make sure we get no heat creep in the heatbreak.