### PR TITLE
Switch electronics cooling fan from a `heater_fan` to a `controller_fan`

### DIFF
--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -374,7 +374,7 @@ kick_start_time: 0.5
 ##	if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan controller_fan]
+[controller_fan controller_fan]
 ##	Controller fan - Z board, HE1 Connector
 pin: z:P2.4
 kick_start_time: 0.5

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -374,7 +374,7 @@ kick_start_time: 0.5
 ##	if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan controller_fan]
+[controller_fan controller_fan]
 ##	Controller fan - Z board, HE1 Connector
 pin: z:P2.4
 kick_start_time: 0.5

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -316,7 +316,7 @@ pin: PB1
 ##	if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan controller_fan]
+[controller_fan controller_fan]
 ##	Controller fan - FAN2 Connector
 pin: PB2
 #kick_start_time: 0.5


### PR DESCRIPTION
Switch to using the `controller_fan` module for the electronics cooling fans on the SKR1.3, SKR1.4, & Spider Klipper configs.
This will bring those configs inline with the electronics cooling fans setting in the Octopus Klipper config.

This change has been tested on the SKR1.3 (by me) and presumably the Octopus since that's already in the repo.  