### PR TITLE
Update Z max position

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -144,7 +144,7 @@ position_endstop: -0.5
 #position_max: 230
 
 ##  Uncomment below for 300mm build
-#position_max: 280
+#position_max: 260
 
 ##  Uncomment below for 350mm build
 #position_max: 330

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -141,13 +141,13 @@ position_endstop: -0.5
 ##--------------------------------------------------------------------
 
 ##  Uncomment below for 250mm build
-#position_max: 230
+#position_max: 210
 
 ##  Uncomment below for 300mm build
 #position_max: 260
 
 ##  Uncomment below for 350mm build
-#position_max: 330
+#position_max: 310
 
 ##--------------------------------------------------------------------
 position_min: -5

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -191,7 +191,7 @@ position_endstop: -0.5
 #position_max: 230
 
 ##  Uncomment below for 300mm build
-#position_max: 280
+#position_max: 260
 
 ##  Uncomment below for 350mm build
 #position_max: 330

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -188,13 +188,13 @@ position_endstop: -0.5
 ##--------------------------------------------------------------------
 
 ##  Uncomment below for 250mm build
-#position_max: 230
+#position_max: 210
 
 ##  Uncomment below for 300mm build
 #position_max: 260
 
 ##  Uncomment below for 350mm build
-#position_max: 330
+#position_max: 310
 
 ##--------------------------------------------------------------------
 position_min: -5

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -191,7 +191,7 @@ position_endstop: -0.5
 #position_max: 230
 
 ##  Uncomment below for 300mm build
-#position_max: 280
+#position_max: 260
 
 ##  Uncomment below for 350mm build
 #position_max: 330

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -188,13 +188,13 @@ position_endstop: -0.5
 ##--------------------------------------------------------------------
 
 ##  Uncomment below for 250mm build
-#position_max: 230
+#position_max: 210
 
 ##  Uncomment below for 300mm build
 #position_max: 260
 
 ##  Uncomment below for 350mm build
-#position_max: 330
+#position_max: 310
 
 ##--------------------------------------------------------------------
 position_min: -5

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -131,13 +131,13 @@ position_endstop: -0.5
 ##--------------------------------------------------------------------
 
 ##  Uncomment below for 250mm build
-#position_max: 230
+#position_max: 210
 
 ##  Uncomment below for 300mm build
 #position_max: 260
 
 ##  Uncomment below for 350mm build
-#position_max: 330
+#position_max: 310
 
 ##--------------------------------------------------------------------
 position_min: -5

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -134,7 +134,7 @@ position_endstop: -0.5
 #position_max: 230
 
 ##  Uncomment below for 300mm build
-#position_max: 280
+#position_max: 260
 
 ##  Uncomment below for 350mm build
 #position_max: 330


### PR DESCRIPTION
280mm is enough to crash the gantry in the top of the printer (On a 300mm build. Probably the same for 250 and 350, but cannot confirm due to lack of those sizes). Lowered it to 260 to prevent this.

Edit:
Removed 20mm from Z on all sizes/configs. It's better that the user milks out the remaining couple of mm's knowingly rather then them crashing their printer to figure out how much to lower it. These should be safe limits with a few mm's to go.