### PR TITLE
Update Voron2_Octopus_Config.cfg

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -269,6 +269,13 @@ run_current: 0.5
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
+##--------------------------------------------------------------------
+
+##  Uncomment below if you are using Octopus Pro and NOT using PT100
+#[static_digital_output max31865]
+#pins: !PF8
+
+##--------------------------------------------------------------------
 
 #####################################################################
 #   Bed Heater
@@ -484,15 +491,13 @@ aliases:
 #[display]
 ##  mini12864 LCD Display
 #lcd_type: uc1701
+#spi_bus: spi1
 #cs_pin: EXP1_3
 #a0_pin: EXP1_4
 #rst_pin: EXP1_5
 #encoder_pins: ^EXP2_5, ^EXP2_3
 #click_pin: ^!EXP1_2
 #contrast: 63
-#spi_software_miso_pin: EXP2_1
-#spi_software_mosi_pin: EXP2_6
-#spi_software_sclk_pin: EXP2_2
 
 #[neopixel btt_mini12864]
 ##  To control Neopixel RGB in mini12864 display


### PR DESCRIPTION
Using `spi_software` means the pins for the SPI bus are being used by the mini12864 display.
Thus precluding their use by SPI driven stepper motors such as the TMC5160
If not using the PT100 sensor on the Octopus Pro, it does however require disabling the MAX31865