### PR TITLE
Shiftingtech display order

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -274,9 +274,9 @@ stealthchop_threshold: 0
 #   Bed Heater
 #####################################################################
 
-[heater_bed]
 ##  SSR Pin - HE1
 ##  Thermistor - TB
+[heater_bed]
 ##  Uncomment the following line if using the default SSR wiring from the docs site
 #heater_pin: PA3
 ##  Other wiring guides may use BED_OUT to control the SSR. Uncomment the following line for those cases
@@ -298,9 +298,11 @@ pid_kd: 363.769
 #   Probe
 #####################################################################
 
-[probe]
 ##  Inductive Probe
 ##  This probe is not used for Z height, only Quad Gantry Leveling
+[probe]
+
+#--------------------------------------------------------------------
 
 ## Select the probe port by type:
 ## For the PROBE port. Will not work with Diode. May need pull-up resistor from signal to 24V.
@@ -326,8 +328,8 @@ samples_tolerance_retries: 3
 #   Fan Control
 #####################################################################
 
-[fan]
 ##  Print Cooling Fan - FAN0
+[fan]
 pin: PA8
 kick_start_time: 0.5
 ##  Depending on your fan, you may need to increase this value
@@ -335,8 +337,9 @@ kick_start_time: 0.5
 ##  if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan hotend_fan]
+
 ##  Hotend Fan - FAN1
+[heater_fan hotend_fan]
 pin: PE5
 max_power: 1.0
 kick_start_time: 0.5
@@ -345,14 +348,14 @@ heater_temp: 50.0
 ##  If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 
-[controller_fan controller_fan]
 ##  Controller fan - FAN2
+[controller_fan controller_fan]
 pin: PD12
 kick_start_time: 0.5
 heater: heater_bed
 
-#[heater_fan exhaust_fan]
 ##  Exhaust fan - FAN3
+#[heater_fan exhaust_fan]
 #pin: PD13
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -389,11 +392,12 @@ home_xy_position:-10,-10
 speed:100
 z_hop:10
 
-[quad_gantry_level]
+
 ##  Use QUAD_GANTRY_LEVEL to level a gantry.
 ##  Min & Max gantry corners - measure from nozzle at MIN (0,0) and 
 ##  MAX (250, 250), (300,300), or (350,350) depending on your printer size
 ##  to respective belt positions
+[quad_gantry_level]
 
 #--------------------------------------------------------------------
 ##  Gantry Corners for 250mm Build
@@ -540,17 +544,18 @@ gcode:
     #G0 X175 Y175 Z30 F3600
     #--------------------------------------------------------------------
     RESTORE_GCODE_STATE NAME=STATE_G32
-   
-[gcode_macro PRINT_START]
+
+
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+[gcode_macro PRINT_START]
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
    
 
-[gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+[gcode_macro PRINT_END]
 gcode:
     # safe anti-stringing move coords
     {% set th = printer.toolhead %}

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -466,8 +466,9 @@ aliases:
 ##  Uncomment the display that you have
 #--------------------------------------------------------------------
 
-#[display]
+
 ##  RepRapDiscount 128x64 Full Graphic Smart Controller
+#[display]
 #lcd_type: st7920
 #cs_pin: EXP1_4
 #sclk_pin: EXP1_5
@@ -481,8 +482,9 @@ aliases:
 
 #--------------------------------------------------------------------
 
-#[display]
+
 ##  mini12864 LCD Display
+#[display]
 #lcd_type: uc1701
 #cs_pin: EXP1_3
 #a0_pin: EXP1_4
@@ -494,8 +496,8 @@ aliases:
 #spi_software_mosi_pin: EXP2_6
 #spi_software_sclk_pin: EXP2_2
 
-#[neopixel btt_mini12864]
 ##  To control Neopixel RGB in mini12864 display
+#[neopixel btt_mini12864]
 #pin: EXP1_6
 #chain_count: 3
 #initial_RED: 0.1

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -58,23 +58,22 @@
 ## SERVO              2.0
 ##===================================================================
 
-
-[mcu]
 ##  MCU for X/Y/E steppers main MCU
 ##  [X in X] - B Motor
 ##  [Y in Y] - A Motor
 ##  [E in E0] - Extruder
+[mcu]
 ##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------
 
-[mcu z]
 ##  MCU for Z steppers
 ##  [Z in X] - Front Left
 ##  [Z1 in Y] - Rear Left
 ##  [Z2 in Z] - Rear Right
 ##  [Z3 in E0]- Front Right
+[mcu z]
 ##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
@@ -92,8 +91,8 @@ square_corner_velocity: 5.0
 #   X/Y Stepper Settings
 #####################################################################
 
-[stepper_x]
 ##  Connected to X on mcu_xye (B Motor)
+[stepper_x]
 step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
@@ -129,8 +128,8 @@ run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-[stepper_y]
 ##  Connected to Y on mcu_xye (A Motor)
+[stepper_y]
 step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
@@ -413,11 +412,11 @@ heater_temp: 45.0
 [idle_timeout]
 timeout: 1800
 
+[safe_z_home]
 ##  XY Location of the Z Endstop Switch
 ##  Update -10,-10 to the XY coordinates of your endstop pin 
 ##  (such as 157,305) after going through Z Endstop Pin
 ##  Location Definition step.
-[safe_z_home]
 home_xy_position:-10,-10
 speed:100
 z_hop:10

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -318,8 +318,8 @@ stealthchop_threshold: 0
 #   Bed Heater
 #####################################################################
 
-[heater_bed]
 ##  SSR Pin - Z board, Fan Pin
+[heater_bed]
 heater_pin: z:P2.3
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
@@ -337,12 +337,11 @@ pid_kd: 363.769
 #####################################################################
 #   Probe
 #####################################################################
-
-[probe]
 ##  Inductive Probe
 ##  This probe is not used for Z height, only Quad Gantry Leveling
 ##  Z_MAX on mcu_z
 ##  If your probe is NO instead of NC, add change pin to !z:P1.24
+[probe]
 pin: z:P1.24
 x_offset: 0
 y_offset: 25.0
@@ -358,8 +357,8 @@ samples_tolerance_retries: 3
 #   Fan Control
 #####################################################################
 
-[heater_fan hotend_fan]
 ##  Hotend Fan - XYE board, HE1 Connector
+[heater_fan hotend_fan]
 pin: P2.4
 max_power: 1.0
 kick_start_time: 0.5
@@ -368,8 +367,8 @@ heater_temp: 50.0
 ##  If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 
-[fan]
 ##  Print Cooling Fan - XYE board, Fan Pin
+[fan]
 pin: P2.3
 kick_start_time: 0.5
 ##  Depending on your fan, you may need to increase this value
@@ -377,15 +376,16 @@ kick_start_time: 0.5
 ##  if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan controller_fan]
+
 ##  Controller fan - Z board, HE1 Connector
+[heater_fan controller_fan]
 pin: z:P2.4
 kick_start_time: 0.5
 heater: heater_bed
 heater_temp: 45.0
 
-#[heater_fan exhaust_fan]
 ##  Exhaust fan - Z board, HE0 Connector
+#[heater_fan exhaust_fan]
 #pin: z:P2.7
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -398,8 +398,8 @@ heater_temp: 45.0
 #   LED Control
 #####################################################################
 
-#[output_pin caselight]
 # Chamber Lighting - Bed Connector (Optional)
+#[output_pin caselight]
 #pin: P2.5
 #pwm:true
 #shutdown_value: 0
@@ -413,21 +413,21 @@ heater_temp: 45.0
 [idle_timeout]
 timeout: 1800
 
-[safe_z_home]
 ##  XY Location of the Z Endstop Switch
 ##  Update -10,-10 to the XY coordinates of your endstop pin 
 ##  (such as 157,305) after going through Z Endstop Pin
 ##  Location Definition step.
+[safe_z_home]
 home_xy_position:-10,-10
 speed:100
 z_hop:10
-   
-[quad_gantry_level]
+
+
 ##  Use QUAD_GANTRY_LEVEL to level a gantry.
 ##  Min & Max gantry corners - measure from nozzle at MIN (0,0) and 
 ##  MAX (250, 250), (300,300), or (350,350) depending on your printer size
 ##  to respective belt positions
-
+[quad_gantry_level]
 #--------------------------------------------------------------------
 ##  Gantry Corners for 250mm Build
 ##  Uncomment for 250mm build
@@ -479,8 +479,8 @@ max_adjust: 10
 ##  Uncomment the display that you have. Display connects to Z MCU
 #--------------------------------------------------------------------
 
-#[display]
 ##  RepRapDiscount 128x64 Full Graphic Smart Controller
+#[display]
 #lcd_type: st7920
 #cs_pin: z:P1.19
 #sclk_pin: z:P1.20
@@ -494,8 +494,8 @@ max_adjust: 10
 
 #--------------------------------------------------------------------
 
-#[display]
 ##  mini12864 LCD Display
+#[display]
 #lcd_type: uc1701
 #cs_pin: z:P1.18
 #a0_pin: z:P1.19
@@ -503,8 +503,8 @@ max_adjust: 10
 #click_pin: ^!z:P0.28
 #contrast: 63
 
-#[neopixel fysetc_mini12864]
 ##  To control Neopixel RGB in mini12864 display
+#[neopixel fysetc_mini12864]
 #pin: z:P1.21
 #chain_count: 3
 #initial_RED: 0.1
@@ -549,16 +549,16 @@ gcode:
     #--------------------------------------------------------------------
     RESTORE_GCODE_STATE NAME=STATE_G32
    
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice   
 [gcode_macro PRINT_START]
-#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
    
 
-[gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+[gcode_macro PRINT_END]
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -59,22 +59,22 @@
 ## PROBE              0.10
 ##===================================================================
 
-[mcu]
 ##  MCU for X/Y/E steppers main MCU
 ##  [X in X] - B Motor
 ##  [Y in Y] - A Motor
 ##  [E in E0] - Extruder
+[mcu]
 ##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------
 
-[mcu z]
 ##  MCU for Z steppers
 ##  [Z in X] - Front Left
 ##  [Z1 in Y] - Rear Left
 ##  [Z2 in Z] - Rear Right
 ##  [Z3 in E0]- Front Right
+[mcu z]
 ##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
@@ -92,8 +92,8 @@ square_corner_velocity: 5.0
 #   X/Y Stepper Settings
 #####################################################################
 
-[stepper_x]
 ##  Connected to X on mcu_xye (B Motor)
+[stepper_x]
 step_pin: P2.2
 dir_pin: !P2.6
 enable_pin: !P2.1
@@ -129,8 +129,8 @@ run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-[stepper_y]
 ##  Connected to Y on mcu_xye (A Motor)
+[stepper_y]
 step_pin: P0.19
 dir_pin: !P0.20
 enable_pin: !P2.8
@@ -318,8 +318,8 @@ stealthchop_threshold: 0
 #   Bed Heater
 #####################################################################
 
-[heater_bed]
 ##  SSR Pin - Z board, Fan Pin
+[heater_bed]
 heater_pin: z:P2.3
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
@@ -338,10 +338,10 @@ pid_kd: 363.769
 #   Probe
 #####################################################################
 
-[probe]
 ##  Inductive Probe
 ##  This probe is not used for Z height, only Quad Gantry Leveling
 ##  Z_MAX on mcu_z
+[probe]
 ##  If your probe is NO instead of NC, change pin to !^z:P0.10
 pin: ^z:P0.10
 x_offset: 0
@@ -358,8 +358,8 @@ samples_tolerance_retries: 3
 #   Fan Control
 #####################################################################
 
-[heater_fan hotend_fan]
 ##  Hotend Fan - XYE board, HE1 Connector
+[heater_fan hotend_fan]
 pin: P2.4
 max_power: 1.0
 kick_start_time: 0.5
@@ -368,8 +368,8 @@ heater_temp: 50.0
 ##  If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 
-[fan]
 ##  Print Cooling Fan - XYE board, Fan Pin
+[fan]
 pin: P2.3
 kick_start_time: 0.5
 ##  Depending on your fan, you may need to increase this value
@@ -377,15 +377,15 @@ kick_start_time: 0.5
 ##  if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan controller_fan]
 ##  Controller fan - Z board, HE1 Connector
+[heater_fan controller_fan]
 pin: z:P2.4
 kick_start_time: 0.5
 heater: heater_bed
 heater_temp: 45.0
 
-#[heater_fan exhaust_fan]
 ##  Exhaust fan - Z board, HE0 Connector
+#[heater_fan exhaust_fan]
 #pin: z:P2.7
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -398,8 +398,8 @@ heater_temp: 45.0
 #   LED Control
 #####################################################################
 
-#[output_pin caselight]
 # Chamber Lighting - Bed Connector (Optional)
+#[output_pin caselight]
 #pin: P2.5
 #pwm:true
 #shutdown_value: 0
@@ -422,12 +422,12 @@ home_xy_position:-10,-10
 speed:100
 z_hop:10
 
-[quad_gantry_level]
+
 ##  Use QUAD_GANTRY_LEVEL to level a gantry.
 ##  Min & Max gantry corners - measure from nozzle at MIN (0,0) and 
 ##  MAX (250, 250), (300,300), or (350,350) depending on your printer size
 ##  to respective belt positions
-
+[quad_gantry_level]
 #--------------------------------------------------------------------
 ##  Gantry Corners for 250mm Build
 ##  Uncomment for 250mm build
@@ -479,8 +479,8 @@ max_adjust: 10
 ##  Uncomment the display that you have. Display connects to Z MCU
 #--------------------------------------------------------------------
 
-#[display]
 ##  RepRapDiscount 128x64 Full Graphic Smart Controller
+#[display]
 #lcd_type: st7920
 #cs_pin: z:P1.19
 #sclk_pin: z:P1.20
@@ -494,8 +494,8 @@ max_adjust: 10
 
 #--------------------------------------------------------------------
 
-#[display]
 ##  mini12864 LCD Display
+#[display]
 #lcd_type: uc1701
 #cs_pin: z:P1.18
 #a0_pin: z:P1.19
@@ -503,8 +503,8 @@ max_adjust: 10
 #click_pin: ^!z:P0.28
 #contrast: 63
 
-#[neopixel fysetc_mini12864]
 ##  To control Neopixel RGB in mini12864 display
+#[neopixel fysetc_mini12864]
 #pin: z:P1.21
 #chain_count: 3
 #initial_RED: 0.1
@@ -547,17 +547,16 @@ gcode:
     #G0 X175 Y175 Z30 F3600
     #--------------------------------------------------------------------
     RESTORE_GCODE_STATE NAME=STATE_G32
-   
-[gcode_macro PRINT_START]
+
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+[gcode_macro PRINT_START]
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
    
-
-[gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+[gcode_macro PRINT_END]
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
@@ -570,3 +569,4 @@ gcode:
     G90                            ; absolute positioning
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
+M

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -33,8 +33,8 @@ square_corner_velocity: 5.0
 #      X/Y Stepper Settings
 #####################################################################
 
-[stepper_x]
 ##  Connected to X-MOT (B Motor)
+[stepper_x]
 step_pin: PE11
 dir_pin: PE10
 enable_pin: !PE9
@@ -71,8 +71,8 @@ run_current: 0.8
 sense_resistor: 0.110
 stealthchop_threshold: 0
 
-[stepper_y]
 ##  Connected to Y-MOT (A Motor)
+[stepper_y]
 step_pin: PD8
 dir_pin: PB12
 enable_pin: !PD9
@@ -199,6 +199,7 @@ rotation_distance: 40
 gear_ratio: 80:16
 microsteps: 32
 
+##  Make sure to update below for your relevant driver (2208 or 2209)
 [tmc2209 stepper_z3]
 uart_pin: PA15
 interpolate: False
@@ -262,8 +263,8 @@ stealthchop_threshold: 0
 #####################################################################
 #   Bed Heater
 #####################################################################
-[heater_bed]
 ##  SSR Pin - In BED OUT position
+[heater_bed]
 heater_pin: PB4
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for Keenovo heaters
@@ -288,9 +289,9 @@ pid_kd: 363.769
 #   Probe
 #####################################################################
 
-[probe]
 ##  This probe is not used for Z height, only Quad Gantry Leveling
 ##  In Z+ position
+[probe]
 ##  If your probe is NO instead of NC, change pin to ^!PA3
 pin: ^PA3
 x_offset: 0
@@ -307,8 +308,8 @@ samples_tolerance_retries: 3
 #   Fan Control
 #####################################################################
 
-[heater_fan hotend_fan]
 ##  Hotend Fan - FAN0 Connector
+[heater_fan hotend_fan]
 ##  Select pin for your Spider board
 ##--------------------------------------------------------------------
 # pin: PB0   # Spider 1.0 & 1.1
@@ -321,8 +322,8 @@ heater_temp: 50.0
 ##  If you are experiencing back flow, you can reduce fan_speed
 #fan_speed: 1.0
 
-[fan]
 ##  Print Cooling Fan - FAN1 Connector
+[fan]
 ##--------------------------------------------------------------------
 #pin: PB1   # Spider 1.0 & 1.1
 #pin: PA14  # Spider 2.2
@@ -334,15 +335,15 @@ heater_temp: 50.0
 ##  if your fan is not able to slow down effectively
 off_below: 0.10
 
-[heater_fan controller_fan]
 ##  Controller fan - FAN2 Connector
+[heater_fan controller_fan]
 pin: PB2
 #kick_start_time: 0.5
 heater: heater_bed
 heater_temp: 45.0
 
-#[heater_fan exhaust_fan]
 ##  Exhaust fan - In E2 OUT Positon
+#[heater_fan exhaust_fan]
 #pin: PB3
 #max_power: 1.0
 #shutdown_speed: 0.0
@@ -355,8 +356,8 @@ heater_temp: 45.0
 #   LED Control
 #####################################################################
 
-#[output_pin caselight]
 ##  Chamber Lighting - In E1 OUT Position
+#[output_pin caselight]
 #pin: PC8
 #pwm: true
 #shutdown_value: 0
@@ -377,12 +378,12 @@ timeout: 1800
 home_xy_position:-10,-10
 speed:100
 z_hop:10
-   
-[quad_gantry_level]
+
 ##  Use QUAD_GANTRY_LEVEL to level a gantry.
 ##  Min & Max gantry corners - measure from nozzle at MIN (0,0) and 
 ##  MAX (250, 250), (300,300), or (350,350) depending on your printer size
 ##  to respective belt positions
+[quad_gantry_level]
 
 #--------------------------------------------------------------------
 ##  Gantry Corners for 250mm Build
@@ -434,8 +435,8 @@ max_adjust: 10
 
 #--------------------------------------------------------------------
 
-[display]
 #   mini12864 LCD Display
+[display]
 lcd_type: uc1701
 cs_pin: PC11
 a0_pin: PD2
@@ -448,8 +449,8 @@ spi_software_mosi_pin: PA7
 spi_software_miso_pin: PA6
 spi_software_sclk_pin: PA5
 
-[neopixel fysetc_mini12864]
 #   To control Neopixel RGB in mini12864 display
+[neopixel fysetc_mini12864]
 pin: PC12
 chain_count: 3
 initial_RED: 0.1
@@ -492,16 +493,16 @@ gcode:
     #G0 X175 Y175 Z30 F3600
     #--------------------------------------------------------------------
     RESTORE_GCODE_STATE NAME=STATE_G32
-   
-[gcode_macro PRINT_START]
+
 #   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+[gcode_macro PRINT_START]
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed 
 
-[gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+[gcode_macro PRINT_END]
 gcode:
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder


### PR DESCRIPTION
I've noticed that a lot of people get tangled up uncommenting mini-12864 stuff, because we're so inconsistent about

##comment
#[section_header]

vs

#[section_header]
##comment

So I cleaned it up globally, going with the first choice, because I think it's easier for the less-code-inclinded among us to see what they need to enable.