### PR TITLE
Remove unnecessary letter in config

### DIFF
--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -569,4 +569,3 @@ gcode:
     G90                            ; absolute positioning
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
-M


### PR DESCRIPTION
There is the letter "M" in line 572 which causes an error.