### PR TITLE
stock config updates 

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -525,6 +525,10 @@ aliases:
 #####################################################################
 #   Macros
 #####################################################################
+[gcode_macro PARK]
+gcode:
+    {% set th = printer.toolhead %}
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} Z30  
 
 [gcode_macro G32]
 gcode:
@@ -533,30 +537,19 @@ gcode:
     G28
     QUAD_GANTRY_LEVEL
     G28
-    ##  Uncomment for for your size printer:
-    #--------------------------------------------------------------------
-    ##  Uncomment for 250mm build
-    #G0 X125 Y125 Z30 F3600
-    
-    ##  Uncomment for 300 build
-    #G0 X150 Y150 Z30 F3600
-    
-    ##  Uncomment for 350mm build
-    #G0 X175 Y175 Z30 F3600
-    #--------------------------------------------------------------------
+    PARK
     RESTORE_GCODE_STATE NAME=STATE_G32
-
-
-#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+   
 [gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
    
 
-#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 [gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
     # safe anti-stringing move coords
     {% set th = printer.toolhead %}

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -528,6 +528,10 @@ max_adjust: 10
 #####################################################################
 #   Macros
 #####################################################################
+[gcode_macro PARK]
+gcode:
+    {% set th = printer.toolhead %}
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} Z30  
 
 [gcode_macro G32]
 gcode:
@@ -536,38 +540,38 @@ gcode:
     G28
     QUAD_GANTRY_LEVEL
     G28
-    ##  Uncomment for for your size printer:
-    #--------------------------------------------------------------------
-    ##  Uncomment for 250mm build
-    #G0 X125 Y125 Z30 F3600
-    
-    ##  Uncomment for 300 build
-    #G0 X150 Y150 Z30 F3600
-    
-    ##  Uncomment for 350mm build
-    #G0 X175 Y175 Z30 F3600
-    #--------------------------------------------------------------------
+    PARK
     RESTORE_GCODE_STATE NAME=STATE_G32
    
-#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice   
 [gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
    
 
-#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 [gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    # safe anti-stringing move coords
+    {% set th = printer.toolhead %}
+    {% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
+    {% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
+    {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
+    
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+    
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-5 F1800                   ; retract filament
-    G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    G1 E-5.0 F1800                 ; retract filament
+    
     TURN_OFF_HEATERS
-    M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
-    G90                            ; absolute positioning
-    G0  X125 Y250 F3600            ; park nozzle at rear
+    
+    G90                                      ; absolute positioning
+    G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
+    M107                                     ; turn off fan
+    
     BED_MESH_CLEAR
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -528,6 +528,10 @@ max_adjust: 10
 #####################################################################
 #   Macros
 #####################################################################
+[gcode_macro PARK]
+gcode:
+    {% set th = printer.toolhead %}
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} Z30  
 
 [gcode_macro G32]
 gcode:
@@ -536,37 +540,38 @@ gcode:
     G28
     QUAD_GANTRY_LEVEL
     G28
-    ##  Uncomment for for your size printer:
-    #--------------------------------------------------------------------
-    ##  Uncomment for 250mm build
-    #G0 X125 Y125 Z30 F3600
-    
-    ##  Uncomment for 300 build
-    #G0 X150 Y150 Z30 F3600
-    
-    ##  Uncomment for 350mm build
-    #G0 X175 Y175 Z30 F3600
-    #--------------------------------------------------------------------
+    PARK
     RESTORE_GCODE_STATE NAME=STATE_G32
-
-#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+   
 [gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
     G1 Z20 F3000                   ; move nozzle away from bed
    
-#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
+
 [gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    # safe anti-stringing move coords
+    {% set th = printer.toolhead %}
+    {% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
+    {% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
+    {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
+    
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+    
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-5 F1800                   ; retract filament
-    G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    G1 E-5.0 F1800                 ; retract filament
+    
     TURN_OFF_HEATERS
-    M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
-    G90                            ; absolute positioning
-    G0  X125 Y250 F3600            ; park nozzle at rear
+    
+    G90                                      ; absolute positioning
+    G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
+    M107                                     ; turn off fan
+    
     BED_MESH_CLEAR
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -474,6 +474,10 @@ gcode:
 #####################################################################
 #   Macros
 #####################################################################
+[gcode_macro PARK]
+gcode:
+    {% set th = printer.toolhead %}
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} Z30  
 
 [gcode_macro G32]
 gcode:
@@ -482,37 +486,38 @@ gcode:
     G28
     QUAD_GANTRY_LEVEL
     G28
-    ##  Uncomment for for your size printer:
-    #--------------------------------------------------------------------
-    ##  Uncomment for 250mm build
-    #G0 X125 Y125 Z30 F3600
-    
-    ##  Uncomment for 300 build
-    #G0 X150 Y150 Z30 F3600
-    
-    ##  Uncomment for 350mm build
-    #G0 X175 Y175 Z30 F3600
-    #--------------------------------------------------------------------
+    PARK
     RESTORE_GCODE_STATE NAME=STATE_G32
-
-#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
+   
 [gcode_macro PRINT_START]
+#   Use PRINT_START for the slicer starting script - please customise for your slicer of choice
 gcode:
     G32                            ; home all axes
     G90                            ; absolute positioning
-    G1 Z20 F3000                   ; move nozzle away from bed 
+    G1 Z20 F3000                   ; move nozzle away from bed
+   
 
-#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 [gcode_macro PRINT_END]
+#   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    # safe anti-stringing move coords
+    {% set th = printer.toolhead %}
+    {% set x_safe = th.position.x + 20 * (1 if th.axis_maximum.x - th.position.x > 20 else -1) %}
+    {% set y_safe = th.position.y + 20 * (1 if th.axis_maximum.y - th.position.y > 20 else -1) %}
+    {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
+    
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+    
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
-    G1 E-5 F1800                ; retract filament
-    G91                            ; relative positioning
-    G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
+    G1 E-5.0 F1800                 ; retract filament
+    
     TURN_OFF_HEATERS
-    M107                           ; turn off fan
-    G1 Z2 F3000                    ; move nozzle up 2mm
-    G90                            ; absolute positioning
-    G0  X125 Y250 F3600            ; park nozzle at rear
+    
+    G90                                      ; absolute positioning
+    G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
+    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
+    M107                                     ; turn off fan
+    
     BED_MESH_CLEAR
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END


### PR DESCRIPTION
Update stock configs to include safe movement in print_end as well as updated G32 macros with pritner.toolhead object to no longer need to uncomment printer size 

added a park macro which is then called in the G32 macro to clean it up as well 
```
[gcode_macro PARK]
gcode:
    {% set th = printer.toolhead %}
    G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y//2} Z30  
```
OLD G32 macro 
```
[gcode_macro G32]
gcode:
    SAVE_GCODE_STATE NAME=STATE_G32
    G90
    G28
    QUAD_GANTRY_LEVEL
    G28
    ##  Uncomment for for your size printer:
    #--------------------------------------------------------------------
    ##  Uncomment for 250mm build
    #G0 X125 Y125 Z30 F3600
    
    ##  Uncomment for 300 build
    #G0 X150 Y150 Z30 F3600
    
    ##  Uncomment for 350mm build
    #G0 X175 Y175 Z30 F3600
    #--------------------------------------------------------------------
    RESTORE_GCODE_STATE NAME=STATE_G32
   ```
   
   NEW G32 macro
   
    [gcode_macro G32]
    gcode:
        SAVE_GCODE_STATE NAME=STATE_G32
        G90
        G28
        QUAD_GANTRY_LEVEL
        G28
        PARK
        RESTORE_GCODE_STATE NAME=STATE_G32
    
    
This PR should also take care of this https://github.com/VoronDesign/Voron-2/pull/275 as well which added the safe movement on print_end

    