### PR TITLE
Make quad gantry leveling safer for new builds

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -439,7 +439,7 @@ z_hop:10
 
 #--------------------------------------------------------------------
 speed: 100
-horizontal_move_z: 10
+horizontal_move_z: 50
 retries: 5
 retry_tolerance: 0.0075
 max_adjust: 10


### PR DESCRIPTION
When I assembled my printer for the first time, my gantry was really out of square. Therefore, the first time I ran quad gantry bed leveling, the nozzle crashed into the bed and created a massive scratch in my PEI sheet. So I propose to change the horizontal_move_z for the default Klipper configuration so that future builders do not have to experience the same thing as me. 

Maybe some documentation regarding why this value is chosen so high should be added in a comment and how it can be changed to make QGL faster.