### PR TITLE
Removed unnecessary bed warping prevention

### DIFF
--- a/firmware/klipper_configurations/M8P/Voron2_M8P_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P_config.cfg
@@ -273,8 +273,7 @@ heater_pin: PB5
 #sensor_type:
 
 sensor_pin: PA0
-##	Adjust Max Power according to 0.4w per square cm. Calculator available at https://tools.takuya.wtf/
-max_power: 0.6
+max_power: 1.0
 min_temp: 0
 max_temp: 120
 control: pid

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -286,8 +286,7 @@ stealthchop_threshold: 0
 ## Use "Generic 3950" for Keenovo heaters
 #sensor_type:
 sensor_pin: PF3
-##  Adjust Max Power so your heater doesn't warp your bed. Rule of thumb is 0.4 watts / cm^2 .
-max_power: 0.6
+max_power: 1.0
 min_temp: 0
 max_temp: 120
 control: pid

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -325,8 +325,7 @@ heater_pin: z:P2.3
 ## Use "Generic 3950" for Keenovo heaters
 #sensor_type:
 sensor_pin: z:P0.23
-##  Adjust Max Power so your heater doesn't warp your bed
-max_power: 0.6
+max_power: 1.0
 min_temp: 0
 max_temp: 120
 control: pid

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -326,8 +326,7 @@ heater_pin: z:P2.3
 ## Use "Generic 3950" for Keenovo heaters
 #sensor_type:
 sensor_pin: z:P0.25
-##  Adjust Max Power so your heater doesn't warp your bed
-max_power: 0.6
+max_power: 1.0
 min_temp: 0
 max_temp: 120
 control: pid

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -277,8 +277,7 @@ heater_pin: PB4
 #sensor_pin: PB0 # Spider 2.2
 ##--------------------------------------------------------------------
 
-##  Adjust Max Power so your heater doesn't warp your bed
-max_power: 0.6
+max_power: 1.0
 min_temp: 0
 max_temp: 120
 control: pid


### PR DESCRIPTION
The default firmware configurations claim that the max_power for bed heating needs to be limited to prevent warping. This seems to be out-of-date.

This PR removes the comments mentioning this, and increasing the default max_bed power to 1.

https://discord.com/channels/460117602945990666/461133450636951552/1059927819615993946
[discord comment](https://discord.com/channels/460117602945990666/461133450636951552/1059927819615993946)
