### PR TITLE
Remove [SAVE|RESTORE]_GCODE_STATE from PRINT_END macro

### DIFF
--- a/firmware/klipper_configurations/M8P/Voron2_M8P_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P_config.cfg
@@ -538,9 +538,12 @@ gcode:
 [gcode_macro PRINT_END]
 #   Use PRINT_END for the slicer ending script - please customise for your slicer of choice
 gcode:
+    SAVE_GCODE_STATE NAME=STATE_PRINT_END
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-10.0 F3600                ; retract filament
+
     G91                            ; relative positioning
     G0 Z1.00 X20.0 Y20.0 F20000    ; move nozzle to remove stringing
     TURN_OFF_HEATERS
@@ -550,4 +553,10 @@ gcode:
     G0  X125 Y250 F3600            ; park nozzle at rear
     BED_MESH_CLEAR
     
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0
 

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -560,17 +560,23 @@ gcode:
     {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
     
     SAVE_GCODE_STATE NAME=STATE_PRINT_END
-    
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-5.0 F1800                 ; retract filament
     
     TURN_OFF_HEATERS
-    
+
     G90                                      ; absolute positioning
     G0 X{x_safe} Y{y_safe} Z{z_safe} F20000  ; move nozzle to remove stringing
     G0 X{th.axis_maximum.x//2} Y{th.axis_maximum.y - 2} F3600  ; park nozzle at rear
     M107                                     ; turn off fan
     
     BED_MESH_CLEAR
-    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -563,7 +563,7 @@ gcode:
     {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
     
     SAVE_GCODE_STATE NAME=STATE_PRINT_END
-    
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-5.0 F1800                 ; retract filament
@@ -576,4 +576,10 @@ gcode:
     M107                                     ; turn off fan
     
     BED_MESH_CLEAR
-    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -563,7 +563,7 @@ gcode:
     {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
     
     SAVE_GCODE_STATE NAME=STATE_PRINT_END
-    
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-5.0 F1800                 ; retract filament
@@ -576,4 +576,10 @@ gcode:
     M107                                     ; turn off fan
     
     BED_MESH_CLEAR
-    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -506,7 +506,7 @@ gcode:
     {% set z_safe = [th.position.z + 2, th.axis_maximum.z]|min %}
     
     SAVE_GCODE_STATE NAME=STATE_PRINT_END
-    
+
     M400                           ; wait for buffer to clear
     G92 E0                         ; zero the extruder
     G1 E-5.0 F1800                 ; retract filament
@@ -519,4 +519,10 @@ gcode:
     M107                                     ; turn off fan
     
     BED_MESH_CLEAR
-    RESTORE_GCODE_STATE NAME=STATE_PRINT_END
+
+    # The purpose of the SAVE_GCODE_STATE/RESTORE_GCODE_STATE
+    # command pair is to restore the printer's coordinate system
+    # and speed settings since the commands above change them.
+    # However, to prevent any accidental, unintentional toolhead
+    # moves when restoring the state, explicitly set MOVE=0.
+    RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0


### PR DESCRIPTION
The sample configuration for some boards contain PRINT_END macros that include [SAVE|RESTORE]_GCODE_STATE command in them.

Unfortunately, those commands may have a negative effect in that the macro tries to perform some safety moves between them to move the toolhead away from the print. However, when the GCode state is restore, Klipper will move the toolhead to the last position before the GCode state is save. This will negate the safety moves and put the toolhead back where it was.

Fix this by removing the [SAVE|RESTORE]_GCODE_STATE command.