### PR TITLE
Update Voron2_Octopus_Config.cfg

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -12,9 +12,11 @@
 ## *** THINGS TO CHANGE/CHECK: ***
 ## MCU paths                            [mcu] section
 ## Thermistor types                     [extruder] and [heater_bed] sections - See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types
+## Hotend heater pin                    [extruder] section
 ## Z Endstop Switch location            [safe_z_home] section
 ## Homing end position                  [gcode_macro G32] section
 ## Z Endstop Switch  offset for Z0      [stepper_z] section
+## Stepper Z1 enable pin                [stepper_z1] section
 ## Probe points                         [quad_gantry_level] section
 ## Min & Max gantry corner postions     [quad_gantry_level] section
 ## PID tune                             [extruder] and [heater_bed] sections
@@ -168,7 +170,10 @@ stealthchop_threshold: 0
 [stepper_z1]
 step_pin: PG4
 dir_pin: PC1
-enable_pin: !PA0
+## Octopus 1.0 & 1.1.  Octopus PRO 1.0
+#enable_pin: !PA0
+## Octopus PRO 1.1
+#enable_pin: !PA2
 rotation_distance: 40
 gear_ratio: 80:16
 microsteps: 32
@@ -243,7 +248,10 @@ microsteps: 32
 full_steps_per_rotation: 200    #200 for 1.8 degree, 400 for 0.9 degree
 nozzle_diameter: 0.400
 filament_diameter: 1.75
-heater_pin: PA2
+## Octopus 1.0 & 1.1.  Octopus PRO 1.0
+#heater_pin: PA2
+## Octopus PRO 1.1
+#heater_pin: PA0
 ## Check what thermistor type you have. See https://www.klipper3d.org/Config_Reference.html#common-thermistors for common thermistor types.
 ## Use "Generic 3950" for NTC 100k 3950 thermistors
 #sensor_type:
@@ -373,7 +381,10 @@ heater: heater_bed
 
 ## Chamber Lighting - HE2 Connector (Optional)
 #[output_pin caselight]
+##Octopus 1.0 & 1.1, Octopus PRO 1.0
 #pin: PB10
+##Octopus PRO 1.1
+#pin: PB0
 #pwm:true
 #shutdown_value: 0
 #value:1


### PR DESCRIPTION
Priority update:  It looks like using an old octopus config file on the PRO 1.1 leads to uncontrolled hotend heating, due to some pin  changes