### PR TITLE
Config cleanups

### DIFF
--- a/firmware/klipper_configurations/Kraken/Voron2_Kraken_Config.cfg
+++ b/firmware/klipper_configurations/Kraken/Voron2_Kraken_Config.cfg
@@ -24,7 +24,7 @@
 ## Fine tune E steps                    [extruder] section
 
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/{REPLACE WITH YOUR SERIAL}
 restart_method: command

--- a/firmware/klipper_configurations/Kraken/Voron2_Kraken_Config.cfg
+++ b/firmware/klipper_configurations/Kraken/Voron2_Kraken_Config.cfg
@@ -24,7 +24,7 @@
 ## Fine tune E steps                    [extruder] section
 
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##  Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/{REPLACE WITH YOUR SERIAL}
 restart_method: command

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v1.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v1.0_config.cfg
@@ -10,7 +10,7 @@
 ##	[X in MOTOR1] - B Motor
 ##	[Y in MOTOR2] - A Motor
 ##	[E in MOTOR8] - Extruder
-##	Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##	Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/YOU_DIDNT_CHANGE_ME_YET
 #restart_method: command

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v1.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v1.0_config.cfg
@@ -10,7 +10,7 @@
 ##	[X in MOTOR1] - B Motor
 ##	[Y in MOTOR2] - A Motor
 ##	[E in MOTOR8] - Extruder
-##	Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##	Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/YOU_DIDNT_CHANGE_ME_YET
 #restart_method: command

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v1.1_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v1.1_config.cfg
@@ -2,7 +2,7 @@
 # To use this config, the firmware should be compiled for the
 # STM32G0B1 with a "8KiB bootloader" and USB communication.
 
-# This config is currently only correct for V1.0 boards
+# This config is currently only correct for V1.1 boards
 # 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -10,7 +10,7 @@
 ##	[X in MOTOR1] - B Motor
 ##	[Y in MOTOR2] - A Motor
 ##	[E in MOTOR8] - Extruder
-##	Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##	Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/YOU_DIDNT_CHANGE_ME_YET
 #restart_method: command

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v1.1_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v1.1_config.cfg
@@ -10,7 +10,7 @@
 ##	[X in MOTOR1] - B Motor
 ##	[Y in MOTOR2] - A Motor
 ##	[E in MOTOR8] - Extruder
-##	Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##	Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/YOU_DIDNT_CHANGE_ME_YET
 #restart_method: command

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v1.1_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v1.1_config.cfg
@@ -1,4 +1,4 @@
-# This file contains common pin mappings for the BIGTREETECH Manta M8P V1.0
+# This file contains common pin mappings for the BIGTREETECH Manta M8P V1.1
 # To use this config, the firmware should be compiled for the
 # STM32G0B1 with a "8KiB bootloader" and USB communication.
 

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
@@ -10,7 +10,7 @@
 ##	[X in MOTOR1] - B Motor
 ##	[Y in MOTOR2] - A Motor
 ##	[E in MOTOR8] - Extruder
-##	Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##	Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/YOU_DIDNT_CHANGE_ME_YET
 #restart_method: command

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
@@ -1,8 +1,8 @@
-# This file contains common pin mappings for the BIGTREETECH Manta M8P V1.0
+# This file contains common pin mappings for the BIGTREETECH Manta M8P V2.0
 # To use this config, the firmware should be compiled for the
 # STM32G0B1 with a "8KiB bootloader" and USB communication.
 
-# This config is currently only correct for V1.0 boards
+# This config is currently only correct for V2.0 boards
 # 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -10,7 +10,7 @@
 ##	[X in MOTOR1] - B Motor
 ##	[Y in MOTOR2] - A Motor
 ##	[E in MOTOR8] - Extruder
-##	Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##	Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/YOU_DIDNT_CHANGE_ME_YET
 #restart_method: command

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -24,7 +24,7 @@
 ## Fine tune E steps                    [extruder] section
 
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/{REPLACE WITH YOUR SERIAL}
 restart_method: command

--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -24,7 +24,7 @@
 ## Fine tune E steps                    [extruder] section
 
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##  Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/{REPLACE WITH YOUR SERIAL}
 restart_method: command

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -63,7 +63,7 @@
 ##  [Y in Y] - A Motor
 ##  [E in E0] - Extruder
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##  Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------
@@ -74,7 +74,7 @@ serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##  [Z2 in Z] - Rear Right
 ##  [Z3 in E0]- Front Right
 [mcu z]
-##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##  Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------

--- a/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.3/Voron2_SKR_13_Config.cfg
@@ -63,7 +63,7 @@
 ##  [Y in Y] - A Motor
 ##  [E in E0] - Extruder
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -64,7 +64,7 @@
 ##  [Y in Y] - A Motor
 ##  [E in E0] - Extruder
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
+##  Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------
@@ -75,7 +75,7 @@ serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##  [Z2 in Z] - Rear Right
 ##  [Z3 in E0]- Front Right
 [mcu z]
-##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##  Obtain definition by "ls /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------

--- a/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
+++ b/firmware/klipper_configurations/SKR_1.4/Voron2_SKR_14_Config.cfg
@@ -64,7 +64,7 @@
 ##  [Y in Y] - A Motor
 ##  [E in E0] - Extruder
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/" then unplug to verify
+##  Obtain definition by "ls -l /dev/serial/by-id/*" then unplug to verify
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_lpc1768_00000-if00
 ##--------------------------------------------------------------------

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -14,7 +14,7 @@
 ## Fine tune E steps                   [extruder] section
 
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/" 
+##  Obtain definition by "ls -l /dev/serial/by-id/*" 
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_000000000000000000000000-if00
 

--- a/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
+++ b/firmware/klipper_configurations/Spider/Voron2_Spider_Config.cfg
@@ -14,7 +14,7 @@
 ## Fine tune E steps                   [extruder] section
 
 [mcu]
-##  Obtain definition by "ls -l /dev/serial/by-id/*" 
+##  Obtain definition by "ls /dev/serial/by-id/*" 
 ##--------------------------------------------------------------------
 serial: /dev/serial/by-id/usb-Klipper_stm32f446xx_000000000000000000000000-if00
 


### PR DESCRIPTION
* changed ls command to `ls /dev/serial/by-id/*`  which is the most user-friendly version of the command
* fixed where I forgot to change some board names in the Manta 1.1 & 2.0 files