### PR TITLE
Bugfix: M8P example config: Correct motor 2 enable pin

### DIFF
--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
@@ -75,7 +75,7 @@ stealthchop_threshold: 0
 [stepper_y]
 step_pin: PE2
 dir_pin: PE1
-enable_pin: !PE0
+enable_pin: !PE4
 microsteps: 16
 rotation_distance: 40
 endstop_pin: ^PF3

--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
@@ -1,6 +1,6 @@
 # This file contains common pin mappings for the BIGTREETECH Manta M8P V2.0
 # To use this config, the firmware should be compiled for the
-# STM32G0B1 with a "8KiB bootloader" and USB communication.
+# STM32H723 with a "8KiB bootloader" and USB communication.
 
 # This config is currently only correct for V2.0 boards
 # 


### PR DESCRIPTION
Previous commit had shared PE0 pin which belongs to m3. This should be correct per m8p v2 pinout docs. Can test on hardware if required.

Credit to u/Torch on discord for spotting: https://discord.com/channels/460117602945990666/460172848565190667/1292147327439736905