### PR TITLE
Bugfix: Correct dir_pin on stepper_z1 and stepper_z2

### DIFF
--- a/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
+++ b/firmware/klipper_configurations/M8P/Voron2_M8P-v2.0_config.cfg
@@ -154,7 +154,7 @@ stealthchop_threshold: 0
 ##	Z1 Stepper - Rear Left on Motor5
 [stepper_z1]
 step_pin: PG13
-dir_pin: PG12
+dir_pin: !PG12
 enable_pin: !PG15
 rotation_distance: 40
 gear_ratio: 80:16
@@ -171,7 +171,7 @@ stealthchop_threshold: 0
 ##	Z2 Stepper - Rear Right on Motor6
 [stepper_z2]
 step_pin: PG9
-dir_pin: !PD7
+dir_pin: PD7
 enable_pin: !PG11
 rotation_distance: 40
 gear_ratio: 80:16


### PR DESCRIPTION
* Correct dir_pin on stepper_z1 and stepper_z2

Tried moving gantry up using sample config. The front side moved up and the back side moved down. 

Checked other sample configs and found ! on dir_pin normally look similar between motors z and z2, and motors z1 and z3. Previous commit has ! on dir_pin similar between motors z and z1, and the motor z2 and z3. 

Swapping the ! on dir_pin on z1 and z2 corrects the issue