### PR TITLE
Update assignments from equals to colon

### DIFF
--- a/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
+++ b/firmware/klipper_configurations/Octopus/Voron2_Octopus_Config.cfg
@@ -260,10 +260,10 @@ min_temp: 10
 max_temp: 270
 max_power: 1.0
 min_extrude_temp: 170
-control = pid
-pid_kp = 26.213
-pid_ki = 1.304
-pid_kd = 131.721
+control: pid
+pid_kp: 26.213
+pid_ki: 1.304
+pid_kd: 131.721
 ##  Try to keep pressure_advance below 1.0
 #pressure_advance: 0.05
 ##  Default is 0.040, leave stock


### PR DESCRIPTION
Updates the assignments in the octopus firmware template for `control`,`pid_kp`,`pid_ki`, and `pid_kd` to use `:` assignment instead of `=`