### PR TITLE
Revise Kraken config for 1.1 board

### DIFF
--- a/firmware/klipper_configurations/Kraken/Voron2_Kraken_Config.cfg
+++ b/firmware/klipper_configurations/Kraken/Voron2_Kraken_Config.cfg
@@ -1,4 +1,7 @@
 # This file contains common pin mappings for the BigTreeTech Kraken.
+# There are small, subtle changes between V1.0 and V1.1 of the Kraken board,
+# including the sense resistor value. See https://bigtreetech.github.io/docs/Kraken.html
+#
 # To use this config, the firmware should be compiled for the STM32H723Z6 with a "128KiB bootloader"
 # Enable "extra low-level configuration options" and select the "25MHz crystal" as clock reference
 
@@ -80,7 +83,7 @@ interpolate: false
 spi_software_miso_pin: PC7
 spi_software_mosi_pin: PC8
 spi_software_sclk_pin: PC6
-sense_resistor: 0.022
+sense_resistor: 0.05 # 0.022 for Kraken v1.0
 run_current: 0.800
 stealthchop_threshold: 0
 ##  sensorless homing, plug in jumper on M2-DIAG
@@ -124,7 +127,7 @@ interpolate: false
 spi_software_miso_pin: PC7
 spi_software_mosi_pin: PC8
 spi_software_sclk_pin: PC6
-sense_resistor: 0.022
+sense_resistor: 0.05 # 0.022 for Kraken v1.0
 run_current: 0.800
 stealthchop_threshold: 0
 ##  sensorless homing, plug in jumper on M2-DIAG
@@ -602,3 +605,4 @@ gcode:
     # However, to prevent any accidental, unintentional toolhead
     # moves when restoring the state, explicitly set MOVE=0.
     RESTORE_GCODE_STATE NAME=STATE_PRINT_END MOVE=0
+


### PR DESCRIPTION
There are small but subtle changes between versions 1.0 and 1.1 of the BIGTREETECH Kraken 1.1 board. Of note, the `Rsense` value has changed for stepper drivers on S1-S4. From the [BTT Product Wiki](https://bigtreetech.github.io/docs/Kraken.html#specifications):

> V1.0：Max 8A driving current for S1-S4(Rsense=22mR)
> V1.1：Max 4.7A driving current for S1-S4(Rsense=50mR)

Accordingly, the values for `sense_resistor:` should change from `0.022` to `0.050`. I hope updating this default saves others many hours of hair pulling and searching!